### PR TITLE
Remove dynamic [[HomeObject]] from decorator return values

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24358,7 +24358,6 @@
             1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
           1. Else,
             1. If IsCallable(_newValue_) is *true*, then
-              1. Perform MakeMethod(_newValue_, _homeObject_).
               1. If _kind_ is ~getter~, then
                 1. Perform SetFunctionName(_newValue_, _key_, *"get"*).
                 1. Set _elementRecord_.[[Get]] to _newValue_.


### PR DESCRIPTION
Removes the dynamic update of the `[[HomeObject]]` of methods returned by decorators. For context, see: https://github.com/tc39/proposal-decorators/issues/497 