### PR TITLE
Throw an error if the value passed to `addInitializer` is not callable

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24262,6 +24262,7 @@
       <emu-alg>
         1. Let _addInitializerClosure_ be a new Abstract Closure with parameters (_initializer_) that captures _initializers_ and _decorationState_ and performs the following steps when called:
           1. If _decorationState_.[[Finished]] is *true*, throw a *TypeError* exception.
+          1. If IsCallable(_initializer_) is *false*, throw a *TypeError* exception.
           1. Append _initializer_ to _initializers_.
           1. Return *undefined*.
         1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *""*, « »).


### PR DESCRIPTION
Addresses this issues: https://github.com/tc39/ecma262/pull/2417#discussion_r873163887