### PR TITLE
Adds Decorator Metadata

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24359,13 +24359,10 @@
           1. Else,
             1. If IsCallable(_newValue_) is *true*, then
               1. If _kind_ is ~getter~, then
-                1. Perform SetFunctionName(_newValue_, _key_, *"get"*).
                 1. Set _elementRecord_.[[Get]] to _newValue_.
               1. Else if _kind_ is ~setter~, then
-                1. Perform SetFunctionName(_newValue_, _key_, *"set"*).
                 1. Set _elementRecord_.[[Set]] to _newValue_.
               1. Else,
-                1. Perform SetFunctionName(_newValue_, _key_).
                 1. Set _elementRecord_.[[Value]] to _newValue_.
             1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
         1. Set _elementRecord_.[[Decorators]] to ~empty~.

--- a/spec.html
+++ b/spec.html
@@ -24330,7 +24330,7 @@
           _name_: a String, a Symbol, or a Private Name,
           _initializers_: a List of function objects,
           _decorationState_: a Record with a field [[Finished]] (a Boolean),
-          _metadataObj_: an Object or ~empty~,
+          _metadataObj_: an Object,
           optional _isStatic_: a Boolean,
         ): an Object
       </h1>
@@ -24362,7 +24362,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"name"*, _name_).
         1. Let _addInitializer_ be CreateAddInitializerFunction(_initializers_, _decorationState_).
         1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"addInitializer"*, _addInitializer_).
-        1. If _metadata_ is not ~empty~, perform ! CreateDataPropertyOrThrow(_contextObj_, *"metadata"*, _metadataObj_).
+        1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"metadata"*, _metadataObj_).
         1. Return _contextObj_.
       </emu-alg>
     </emu-clause>
@@ -24384,6 +24384,7 @@
       <emu-alg>
         1. Let _decorators_ be _elementRecord_.[[Decorators]].
         1. If _decorators_ is ~empty~, return ~unused~.
+        1. Assert: _metadataObj_ is not ~empty~.
         1. Let _key_ be _elementRecord_.[[Key]].
         1. Let _kind_ be _elementRecord_.[[Kind]].
         1. For each element _decoratorRecord_ of _decorators_, do
@@ -24446,6 +24447,7 @@
       </dl>
       <emu-alg>
         1. For each element _decoratorRecord_ of _decorators_, do
+          1. Assert: _metadataObj_ is not ~empty~.
           1. Let _decorator_ be _decoratorRecord_.[[Decorator]].
           1. Let _decoratorReceiver_ be _decoratorRecord_.[[Receiver]].
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
@@ -30628,7 +30630,6 @@
         <li>does not have a *"prototype"* property.</li>
         <li>has a *"length"* property whose value is *+0*<sub>𝔽</sub>.</li>
         <li>has a *"name"* property whose value is the empty String.</li>
-        <li>has a @@metadata property whose value is *null*, which is non-writable and non-configurable to prevent tampering that could be used to globally add metadata to all classes.</li>
       </ul>
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>
@@ -30753,6 +30754,13 @@
         </emu-note>
         <p>This property is non-writable and non-configurable to prevent tampering that could be used to globally expose the target function of a bound function.</p>
         <p>The value of the *"name"* property of this method is *"[Symbol.hasInstance]"*.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-function.prototype-@@metadata">
+        <h1>Symbol.prototype [ @@metadata ]</h1>
+        <p>The initial value of the @@metadata property is *null*.</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+        <p>This property is non-writable and non-configurable to prevent tampering that could be used to globally expose the target function of a bound function.</p>
       </emu-clause>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -25257,7 +25257,7 @@
         1. Let _instanceExtraInitializers_ be a new empty List.
         1. Let _staticExtraInitializers_ be a new empty List.
         1. Let _metadataParent_ be ? Get(_constructorParent_, @@metadata).
-        1. If _metadataParent_ is *undefined*, let _metadataParent_ be %Object.prototype%.
+        1. If _metadataParent_ is *undefined*, let _metadataParent_ be *null*.
         1. Let _metadataObj_ be OrdinaryObjectCreate(_metadataParent_).
         1. For each element _e_ of _staticElements_, do
           1. If _e_ is a ClassElementDefinition Record and _e_.[[Kind]] is not ~field~, then

--- a/spec.html
+++ b/spec.html
@@ -24388,7 +24388,7 @@
           1. Let _newValue_ be ? Call(_decorator_, _decoratorReceiver_, « _value_, _context_ »).
           1. Set _decorationState_.[[Finished]] to *true*.
           1. If _kind_ is ~field~, then
-            1. If IsCallable(_newValue_) is *true*, append _newValue_ to _elementRecord_.[[Initializers]].
+            1. If IsCallable(_newValue_) is *true*, prepend _newValue_ to _elementRecord_.[[Initializers]].
             1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
           1. Else if _kind_ is ~accessor~, then
             1. If _newValue_ is an Object, then
@@ -24399,7 +24399,7 @@
               1. If IsCallable(_newSetter_) is *true*, set _elementRecord_.[[Set]] to _newSetter_.
               1. Else if _newSetter_ is not *undefined*, throw a *TypeError* exception.
               1. Let _initializer_ be ? Get(_newValue_, *"init"*).
-              1. If IsCallable(_initializer_) is *true*, append _initializer_ to _elementRecord_.[[Initializers]].
+              1. If IsCallable(_initializer_) is *true*, prepend _initializer_ to _elementRecord_.[[Initializers]].
               1. Else if _initializer_ is not *undefined*, throw a *TypeError* exception.
             1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
           1. Else,

--- a/spec.html
+++ b/spec.html
@@ -24358,7 +24358,6 @@
             1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
           1. Else,
             1. If IsCallable(_newValue_) is *true*, then
-              1. Perform MakeMethod(_newValue_, _homeObject_).
               1. If _kind_ is ~getter~, then
                 1. Perform SetFunctionName(_newValue_, _key_, *"get"*).
                 1. Set _elementRecord_.[[Get]] to _newValue_.

--- a/spec.html
+++ b/spec.html
@@ -6799,8 +6799,7 @@
         1. Let _privateMethods_ be a new empty List.
         1. For each element _element_ of _elementDefinitions_, do
           1. If _element_.[[Key]] is a Private Name and _element_.[[Kind]] is ~method~, ~getter~, ~setter~, or ~accessor~, then
-            1. If _privateMethods_ contains a PrivateElement whose [[Key]] is _element_.[[Key]], then
-              1. Let _existing_ be that PrivateElement.
+            1. If _privateMethods_ contains a PrivateElement _existing_ such that _existing.[[Key]] is _element_.[[Key]], then
               1. Assert: _element_.[[Kind]] is ~getter~ or ~setter~.
               1. Assert: _existing_.[[Kind]] is ~accessor~.
               1. If _element_.[[Get]] is *undefined*, then
@@ -6819,7 +6818,7 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-initializefieldoraccessor" type="abstract operation">
+    <emu-clause id="sec-initializefieldoraccessor" oldids="sec-definefield" type="abstract operation">
       <h1>
         InitializeFieldOrAccessor (
           _receiver_: an Object,
@@ -24176,19 +24175,19 @@
       <emu-grammar>Decorator : `@` DecoratorMemberExpression</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |MemberExpression| that is covered by |DecoratorMemberExpression|.
-        1. Let _ref_ be the result of evaluating _expr_.
+        1. Let _ref_ be ? Evaluation of _expr_.
         1. Return ? GetValue(_ref_).
       </emu-alg>
       <emu-grammar>Decorator : `@` DecoratorCallExpression</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |CallMemberExpression| that is covered by |DecoratorCallExpression|.
-        1. Let _ref_ be the result of evaluating _expr_.
+        1. Let _ref_ be ? Evaluation of _expr_.
         1. Return ? GetValue(_ref_).
       </emu-alg>
       <emu-grammar>Decorator : `@` DecoratorParenthesizedExpression</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |MemberExpression| that is covered by |DecoratorParenthesizedExpression|.
-        1. Let _ref_ be the result of evaluating _expr_.
+        1. Let _ref_ be ? Evaluation of _expr_.
         1. Return ? GetValue(_ref_).
       </emu-alg>
     </emu-clause>
@@ -24945,6 +24944,7 @@
           1. Let _o_ be the *this* value.
           1. Return ? PrivateGet(_privateStateName_, _o_).
         1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *"get"*, « »).
+        1. Perform SetFunctionName(_getter_, _name_, *"get"*).
         1. Perform MakeMethod(_getter_, _homeObject_).
         1. Return _getter_.
       </emu-alg>
@@ -24966,6 +24966,7 @@
           1. Perform ? PrivateSet(_privateStateName_, _o_, _value_).
           1. Return *undefined*.
         1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, *"set"*, « »).
+        1. Perform SetFunctionName(_setter_, _name_, *"set"*).
         1. Perform MakeMethod(_setter_, _homeObject_).
         1. Return _setter_.
       </emu-alg>
@@ -24997,7 +24998,7 @@
         1. Let _name_ be the result of evaluating |ClassElementName|.
         1. ReturnIfAbrupt(_name_).
         1. Let _privateStateDesc_ be the string-concatenation of _name_ and *" accessor storage"*.
-        1. Let _privateStateName_ be a new Private Name whose [[Description]] value is _privateStateDesc_.
+        1. Let _privateStateName_ be a new Private Name whose [[Description]] is _privateStateDesc_.
         1. Let _getter_ be MakeAutoAccessorGetter(_homeObject_, _name_, _privateStateName_).
         1. Let _setter_ be MakeAutoAccessorSetter(_homeObject_, _name_, _privateStateName_).
         1. Let _initializers_ be a new empty List.
@@ -25255,7 +25256,7 @@
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo">
       <h1>
         Runtime Semantics: BindingClassDeclarationEvaluation (
-          _decorators_: a List,
+          _decorators_: a List of function objects,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
@@ -28694,7 +28695,7 @@
             It is a Syntax Error if |DecoratorList| is present and |Declaration| is not |ClassDeclaration|.
           </li>
           <li>
-            It is a Syntax Error if |DecoratorList| is present and |Declaration| is a |ClassDeclaration| and the |DecoratorList| of that |ClassDeclaration| is present.
+            It is a Syntax Error if |DecoratorList| is present, |Declaration| is a |ClassDeclaration|, and the |DecoratorList| of that |ClassDeclaration| is present.
           </li>
         </ul>
         <emu-grammar>ExportDeclaration : DecoratorList? `export` `default` ClassDeclaration</emu-grammar>
@@ -47788,8 +47789,8 @@ THH:mm:ss.sss
     <emu-prodref name="DecoratorList"></emu-prodref>
     <emu-prodref name="Decorator"></emu-prodref>
     <emu-prodref name="DecoratorMemberExpression"></emu-prodref>
-    <emu-prodref name="DecoratorCallExpression"></emu-prodref>
     <emu-prodref name="DecoratorParenthesizedExpression"></emu-prodref>
+    <emu-prodref name="DecoratorCallExpression"></emu-prodref>
     <emu-prodref name="ClassDeclaration"></emu-prodref>
     <emu-prodref name="ClassExpression"></emu-prodref>
     <emu-prodref name="ClassTail"></emu-prodref>

--- a/spec.html
+++ b/spec.html
@@ -6797,8 +6797,8 @@
       </dl>
       <emu-alg>
         1. Let _privateMethods_ be a new empty List.
-        1. For each element _e_ of _elementDefinitions_, do
-          1. If _e_.[[Key]] is a Private Name and _e_.[[Kind]] is ~method~, ~getter~, ~setter~, or ~accessor~, then
+        1. For each element _element_ of _elementDefinitions_, do
+          1. If _element_.[[Key]] is a Private Name and _element_.[[Kind]] is ~method~, ~getter~, ~setter~, or ~accessor~, then
             1. If _privateMethods_ contains a PrivateElement whose [[Key]] is _element_.[[Key]], then
               1. Let _existing_ be that PrivateElement.
               1. Assert: _element_.[[Kind]] is ~getter~ or ~setter~.
@@ -6815,7 +6815,7 @@
               1. Append _privateElement_ to _privateMethods_.
         1. For each element _method_ of _privateMethods_, do
           1. Perform ? PrivateMethodOrAccessorAdd(_O_, _method_).
-          1. Return ~unused~.
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -6834,7 +6834,7 @@
         1. Else, let _fieldName_ be _elementRecord_.[[Key]].
         1. Let _initValue_ be *undefined*.
         1. For each element _initializer_ of _elementRecord_.[[Initializers]], do
-          1. Set _initValue_ to ? Call(_initializer_, _receiver_, &laquo; _initValue_ &raquo;).
+          1. Set _initValue_ to ? Call(_initializer_, _receiver_, « _initValue_ »).
         1. If _fieldName_ is a Private Name, then
           1. Perform ? PrivateFieldAdd(_receiver_, _fieldName_, _initValue_).
         1. Else,
@@ -6859,8 +6859,8 @@
         1. For each element _initializer_ of _constructor_.[[Initializers]], do
           1. Perform ? Call(_O_, _initializer_).
         1. For each element _e_ of _elements_, do
-          1. If _elementRecord_.[[Kind]] is ~field~ or ~accessor~, then
-            1. Perform ? InitializeFieldOrAccessor(_O_, _elementRecord_).
+          1. If _e_.[[Kind]] is ~field~ or ~accessor~, then
+            1. Perform ? InitializeFieldOrAccessor(_O_, _e_).
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>
@@ -9385,7 +9385,7 @@
           DecoratorList? `static` MethodDefinition
       </emu-grammar>
       <emu-alg>
-        1. Return ComputedPropertyContains of |MethodDefinition|.
+        1. Return ComputedPropertyContains of |MethodDefinition| with argument _symbol_.
       </emu-alg>
       <emu-grammar>
         ClassElement :
@@ -9393,7 +9393,7 @@
           DecoratorList? `static` FieldDefinition `;`
       </emu-grammar>
       <emu-alg>
-        1. Return ComputedPropertyContains of |FieldDefinition|.
+        1. Return ComputedPropertyContains of |FieldDefinition| with argument _symbol_.
       </emu-alg>
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
       <emu-alg>
@@ -13188,7 +13188,7 @@
             [[Initializers]]
           </td>
           <td>
-            a List of function objects | ~empty~
+            a List of function objects
           </td>
           <td>
             If the function is a class with decorated prototype methods or accessors, this is a list of initializer functions added by the decorators, or ~empty~.
@@ -24159,8 +24159,8 @@
 
       DecoratorMemberExpression[Yield, Await] :
         IdentifierReference[?Yield, ?Await]
-        PrivateIdentifier
         DecoratorMemberExpression[?Yield, ?Await] `.` IdentifierName
+        DecoratorMemberExpression[?Yield, ?Await] `.` PrivateIdentifier
 
       DecoratorParenthesizedExpression[Yield, Await] :
         `(` Expression[+In, ?Yield, ?Await] `)`
@@ -24223,11 +24223,11 @@
       <emu-alg>
         1. Let _accessObj_ be OrdinaryObjectCreate(%Object.prototype%).
         1. If _kind_ is ~field~, ~method~, ~accessor~, or ~getter~, then
-          1. Let _getterClosure_ be a new Abstract Closure with parameter (_obj_) that captures _name_ and performs the following steps when called:
+          1. Let _getterClosure_ be a new Abstract Closure with parameters (_obj_) that captures _name_ and performs the following steps when called:
             1. If _obj_ is not an Object, throw a *TypeError* exception.
             1. If _name_ is either a String or a Symbol, return ? Get(_obj_, _name_).
             1. Else, return ? PrivateGet(_name_, _obj_).
-          1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 1, *""*, &laquo; &raquo;).
+          1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 1, *""*, « »).
           1. Perform ! CreateDataPropertyOrThrow(_accessObj_, *"get"*, _getter_).
         1. If _kind_ is ~field~, ~accessor~, or ~setter~, then
           1. Let _setterClosure_ be a new Abstract Closure with parameters (_obj_, _value_) that captures _name_ and performs the following steps when called:
@@ -24235,14 +24235,14 @@
             1. If _name_ is either a String or a Symbol, perform ? Set(_obj_, _name_, _value_, *true*).
             1. Else, perform ? PrivateSet(_name_, _obj_, _value_).
             1. Return *undefined*.
-          1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 2, *""*, &laquo; &raquo;).
+          1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 2, *""*, « »).
           1. Perform ! CreateDataPropertyOrThrow(_accessObj_, *"set"*, _setter_).
-        1. Let _hasClosure_ be a new Abstract Closure with parameter (_obj_) that captures _name_ and performs the following steps when called:
+        1. Let _hasClosure_ be a new Abstract Closure with parameters (_obj_) that captures _name_ and performs the following steps when called:
           1. If _obj_ is not an Object, throw a *TypeError* exception.
           1. If _name_ is either a String or a Symbol, return ? HasProperty(_obj_, _name_).
           1. If PrivateElementFind(_obj_, _name_) is not ~empty~, return *true*.
           1. Return *false*.
-        1. Let _has_ be CreateBuiltinFunction(_hasClosure_, 1, *""*, &laquo; &raquo;).
+        1. Let _has_ be CreateBuiltinFunction(_hasClosure_, 1, *""*, « »).
         1. Perform ! CreateDataPropertyOrThrow(_accessObj_, *"has"*, _has_).
         1. Return _accessObj_.
       </emu-alg>
@@ -24264,7 +24264,7 @@
           1. If _decorationState_.[[Finished]] is *true*, throw a *TypeError* exception.
           1. Append _initializer_ to _initializers_.
           1. Return *undefined*.
-        1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *""*, &laquo; &raquo;).
+        1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *""*, « »).
       </emu-alg>
     </emu-clause>
 
@@ -24272,7 +24272,7 @@
       <h1>
         CreateDecoratorContextObject (
           _kind_: ~class~, ~field~, ~method~, ~accessor~, ~getter~, or ~setter~,
-          _name_: a String, a Symbol, or Private Name,
+          _name_: a String, a Symbol, or a Private Name,
           _initializers_: a List of function objects,
           _decorationState_: a Record with a field [[Finished]] (a Boolean),
           optional _isStatic_: a Boolean,
@@ -24337,13 +24337,13 @@
           1. Else if _kind_ is ~setter~, set _value_ to _elementRecord_.[[Set]].
           1. Else if _kind_ is ~accessor~, then
             1. Set _value_ to OrdinaryObjectCreate(%Object.prototype%).
-            1. Perform ! CreateDataPropertyOrThrow(_accessor_, *"get"*, _elementRecord_.[[Get]]).
-            1. Perform ! CreateDataPropertyOrThrow(_accessor_, *"set"*, _elementRecord_.[[Set]]).
-          1. Let _newValue_ be ? Call(_decorator_, *undefined*, &laquo; _value_, _context_ &raquo;).
+            1. Perform ! CreateDataPropertyOrThrow(_value_, *"get"*, _elementRecord_.[[Get]]).
+            1. Perform ! CreateDataPropertyOrThrow(_value_, *"set"*, _elementRecord_.[[Set]]).
+          1. Let _newValue_ be ? Call(_decorator_, *undefined*, « _value_, _context_ »).
           1. Set _decorationState_.[[Finished]] to *true*.
           1. If _kind_ is ~field~, then
-            1. If IsCallable(_initializer_) is *true*, append _initializer_ to _elementRecord_.[[Initializers]].
-            1. Else if _initializer_ is not *undefined*, throw a *TypeError* exception.
+            1. If IsCallable(_newValue_) is *true*, append _newValue_ to _elementRecord_.[[Initializers]].
+            1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
           1. Else if _kind_ is ~accessor~, then
             1. If _newValue_ is an Object, then
               1. Let _newGetter_ be ? Get(_newValue_, *"get"*).
@@ -24379,6 +24379,7 @@
         ApplyDecoratorsToClassDefinition (
           _classDef_: a function object,
           _decorators_: a List of function objects,
+          _className_: a property key or a Private Name,
           _extraInitializers_: a List of function objects,
         ): either a normal completion containing a function object, or an abrupt completion
       </h1>
@@ -24389,8 +24390,8 @@
       <emu-alg>
         1. For each element _decorator_ of _decorators_, do
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
-          1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _classExtraInitializers_, _decorationState_).
-          1. Let _newDef_ be ? Call(_decorator_, *undefined*, &laquo; _classDef_, _context_ &raquo;).
+          1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _extraInitializers_, _decorationState_).
+          1. Let _newDef_ be ? Call(_decorator_, *undefined*, « _classDef_, _context_ »).
           1. Set _decorationState_.[[Finished]] to *true*.
           1. If IsCallable(_newDef_) is *true*, then
             1. Set _classDef_ to _newDef_.
@@ -24893,8 +24894,8 @@
       <h1>
         ApplyDecoratorsAndDefineMethod (
           _homeObject_: an Object,
-          _methodDefinition_: a ClassElementDefinition record,
-          _extraInitializers_: A List of function objects,
+          _methodDefinition_: a ClassElementDefinition Record,
+          _extraInitializers_: a List of function objects,
           _isStatic_: a Boolean,
         ): either a normal completion containing ~unused~, or an abrupt completion
       </h1>
@@ -24912,7 +24913,7 @@
         CreateFieldInitializerFunction (
           _homeObject_: an Object,
           _propName_: a property key or Private Name,
-          _Initializer_: a function object,
+          _Initializer_: a Parse Node,
         ): a function object
       </h1>
       <dl class="header">
@@ -24943,7 +24944,7 @@
         1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _privateStateName_ and performs the following steps when called:
           1. Let _o_ be the *this* value.
           1. Return ? PrivateGet(_privateStateName_, _o_).
-        1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *"get"*, &laquo; &raquo;).
+        1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *"get"*, « »).
         1. Perform MakeMethod(_getter_, _homeObject_).
         1. Return _getter_.
       </emu-alg>
@@ -24964,7 +24965,7 @@
           1. Let _o_ be the *this* value.
           1. Perform ? PrivateSet(_privateStateName_, _o_, _value_).
           1. Return *undefined*.
-        1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, *"set"*, &laquo; &raquo;).
+        1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, *"set"*, « »).
         1. Perform MakeMethod(_setter_, _homeObject_).
         1. Return _setter_.
       </emu-alg>
@@ -25194,7 +25195,7 @@
         1. Let _instanceExtraInitializers_ be a new empty List.
         1. Let _staticExtraInitializers_ be a new empty List.
         1. For each element _e_ of _staticElements_, do
-          1. If _e_.[[Kind]] is not ~field~, then
+          1. If _e_ is a ClassElementDefinition Record and _e_.[[Kind]] is not ~field~, then
             1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_F_, _e_, _staticExtraInitializers_, *true*)).
             1. If _result_ is an abrupt completion, then
               1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
@@ -25219,16 +25220,15 @@
               1. Return ? _result_.
         1. Set _F_.[[Elements]] to _instanceElements_.
         1. Set _F_.[[Initializers]] to _instanceExtraInitializers_.
-        1. For each PrivateElement _method_ of _staticPrivateMethods_, do
-          1. Perform ! PrivateMethodOrAccessorAdd(_F_, _method_).
+        1. Perform ? InitializePrivateMethods(_F_, _staticElements_).
         1. Let _classExtraInitializers_ be a new empty List.
-        1. Let _newF_ be Completion(ApplyDecoratorsToClassDefinition(_F_, _decorators_, _classExtraInitializers_)).
+        1. Let _newF_ be Completion(ApplyDecoratorsToClassDefinition(_F_, _decorators_, _className_, _classExtraInitializers_)).
         1. If _newF_ is an abrupt completion, then
           1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
           1. Return ? _result_.
         1. Set _F_ to _newF_.[[Value]].
         1. If _classBinding_ is not *undefined*, then
-          1. Perform _classScope_.InitializeBinding(_classBinding_, _F_).
+          1. Perform _classEnv_.InitializeBinding(_classBinding_, _F_).
         1. For each element _initializer_ of _staticExtraInitializers_, do
           1. Let _result_ be Completion(Call(_initializer_, _F_)).
           1. If _result_ is an abrupt completion, then

--- a/spec.html
+++ b/spec.html
@@ -24264,7 +24264,7 @@
           1. If _decorationState_.[[Finished]] is *true*, throw a *TypeError* exception.
           1. Append _initializer_ to _initializers_.
           1. Return *undefined*.
-        1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *""*, « »).
+        1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *"addInitializer"*, « »).
       </emu-alg>
     </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -4577,7 +4577,7 @@
               [[Key]]
             </td>
             <td>
-              All
+              ~field~, ~method~, or ~accessor~
             </td>
             <td>
               a Private Name
@@ -4591,7 +4591,7 @@
               [[Kind]]
             </td>
             <td>
-              All
+              ~field~, ~method~, or ~accessor~
             </td>
             <td>
               ~field~, ~method~, or ~accessor~
@@ -4646,15 +4646,18 @@
       </emu-table>
     </emu-clause>
 
-    <emu-clause id="sec-classfielddefinition-record-specification-type">
-      <h1>The ClassFieldDefinition Record Specification Type</h1>
-      <p>The ClassFieldDefinition type is a Record used in the specification of class fields.</p>
-      <p>Values of the ClassFieldDefinition type are Record values whose fields are defined by <emu-xref href="#table-classfielddefinition-fields"></emu-xref>. Such values are referred to as <dfn variants="ClassFieldDefinition Record">ClassFieldDefinition Records</dfn>.</p>
-      <emu-table id="table-classfielddefinition-fields" caption="ClassFieldDefinition Record Fields">
+    <emu-clause id="sec-classelementdefinition-record-specification-type" oldids="sec-classfielddefinition-record-specification-type">
+      <h1>The ClassElementDefinition Record Specification Type</h1>
+      <p>The ClassElementDefinition type is a Record used in the specification of private and public, static and non-static class fields, methods, and accessors.</p>
+      <p>Values of the ClassElementDefinition type are Record values whose fields are defined by <emu-xref href="#table-classelementdefinition-fields"></emu-xref>. Such values are referred to as <dfn variants="ClassElementDefinition Record">ClassElementDefinition Records</dfn>.</p>
+      <emu-table id="table-classelementdefinition-fields" caption="ClassElementDefinition Record Fields" oldids="table-classfielddefinition-fields">
         <table>
           <tr>
             <th>
               Field Name
+            </th>
+            <th>
+              Values of the [[Kind]] field for which it is present
             </th>
             <th>
               Value
@@ -4665,7 +4668,10 @@
           </tr>
           <tr>
             <td>
-              [[Name]]
+              [[Key]]
+            </td>
+            <td>
+              ~field~, ~method~, ~accessor~, ~getter~, ~setter~
             </td>
             <td>
               a Private Name, a String, or a Symbol
@@ -4676,13 +4682,100 @@
           </tr>
           <tr>
             <td>
-              [[Initializer]]
+              [[Kind]]
             </td>
             <td>
-              a function object or ~empty~
+              ~field~, ~method~, ~accessor~, ~getter~, or ~setter~
             </td>
             <td>
-              The initializer of the field, if any.
+              ~field~, ~method~, ~accessor~, ~getter~, or ~setter~
+            </td>
+            <td>
+              The kind of the element.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Value]]
+            </td>
+            <td>
+              ~method~
+            </td>
+            <td>
+              a function object
+            </td>
+            <td>
+              The function for a method definition.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Get]]
+            </td>
+            <td>
+              ~accessor~ and ~getter~
+            </td>
+            <td>
+              a function object
+            </td>
+            <td>
+              The getter for an accessor definition.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Set]]
+            </td>
+            <td>
+              ~accessor~ and ~setter~
+            </td>
+            <td>
+              a function object
+            </td>
+            <td>
+              The setter for an accessor definition.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[BackingStorageKey]]
+            </td>
+            <td>
+              ~accessor~
+            </td>
+            <td>
+              a Private Name
+            </td>
+            <td>
+              A private name for the backing state behind accessors defined with the `accessor` keyword
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Decorators]]
+            </td>
+            <td>
+              ~field~, ~method~, ~accessor~, ~getter~, ~setter~
+            </td>
+            <td>
+              a List of function objects or ~empty~
+            </td>
+            <td>
+              The decorators applied to the class element, if any.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[Initializers]]
+            </td>
+            <td>
+              ~field~ and ~accessor~
+            </td>
+            <td>
+              a List of function objects
+            </td>
+            <td>
+              The initializers of the field or accessor, if any.
             </td>
           </tr>
         </table>
@@ -6693,21 +6786,55 @@
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-definefield" type="abstract operation">
+    <emu-clause id="sec-initializeprivatemethods" type="abstract operation">
       <h1>
-        DefineField (
-          _receiver_: an Object,
-          _fieldRecord_: a ClassFieldDefinition Record,
-        ): either a normal completion containing ~unused~ or a throw completion
+        InitializePrivateMethods (
+          _O_: an Object,
+          _elementDefinitions_: a List of ClassElementDefinition Records,
+        ): either a normal completion containing ~unused~ or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _fieldName_ be _fieldRecord_.[[Name]].
-        1. Let _initializer_ be _fieldRecord_.[[Initializer]].
-        1. If _initializer_ is not ~empty~, then
-          1. Let _initValue_ be ? Call(_initializer_, _receiver_).
-        1. Else, let _initValue_ be *undefined*.
+        1. Let _privateMethods_ be a new empty List.
+        1. For each element _e_ of _elementDefinitions_, do
+          1. If _e_.[[Key]] is a Private Name and _e_.[[Kind]] is ~method~, ~getter~, ~setter~, or ~accessor~, then
+            1. If _privateMethods_ contains a PrivateElement whose [[Key]] is _element_.[[Key]], then
+              1. Let _existing_ be that PrivateElement.
+              1. Assert: _element_.[[Kind]] is ~getter~ or ~setter~.
+              1. Assert: _existing_.[[Kind]] is ~accessor~.
+              1. If _element_.[[Get]] is *undefined*, then
+                1. Let _combined_ be PrivateElement { [[Key]]: _existing_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _existing_.[[Get]], [[Set]]: _element_.[[Set]] }.
+              1. Else,
+                1. Let _combined_ be PrivateElement { [[Key]]: _existing_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _element_.[[Get]], [[Set]]: _existing_.[[Set]] }.
+              1. Replace _existing_ in _privateMethods_ with _combined_.
+            1. Else,
+              1. If _element_.[[Kind]] is ~getter~ or ~setter~, let _kind_ be ~accessor~.
+              1. Else, let _kind_ be _element_.[[Kind]].
+              1. Let _privateElement_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: _kind_, [[Value]]: _element_.[[Value]], [[Get]]: _element_.[[Get]], [[Set]]: _element_.[[Set]] }.
+              1. Append _privateElement_ to _privateMethods_.
+        1. For each element _method_ of _privateMethods_, do
+          1. Perform ? PrivateMethodOrAccessorAdd(_O_, _method_).
+          1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-initializefieldoraccessor" type="abstract operation">
+      <h1>
+        InitializeFieldOrAccessor (
+          _receiver_: an Object,
+          _elementRecord_: a ClassElementDefinition Record,
+        ): either a normal completion containing ~unused~ or an abrupt completion
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Assert: _elementRecord_.[[Kind]] is ~field~ or ~accessor~.
+        1. If _elementRecord_.[[BackingStorageKey]] is present, let _fieldName_ be _elementRecord_.[[BackingStorageKey]].
+        1. Else, let _fieldName_ be _elementRecord_.[[Key]].
+        1. Let _initValue_ be *undefined*.
+        1. For each element _initializer_ of _elementRecord_.[[Initializers]], do
+          1. Set _initValue_ to ? Call(_initializer_, _receiver_, &laquo; _initValue_ &raquo;).
         1. If _fieldName_ is a Private Name, then
           1. Perform ? PrivateFieldAdd(_receiver_, _fieldName_, _initValue_).
         1. Else,
@@ -6727,12 +6854,13 @@
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Let _methods_ be the value of _constructor_.[[PrivateMethods]].
-        1. For each PrivateElement _method_ of _methods_, do
-          1. Perform ? PrivateMethodOrAccessorAdd(_O_, _method_).
-        1. Let _fields_ be the value of _constructor_.[[Fields]].
-        1. For each element _fieldRecord_ of _fields_, do
-          1. Perform ? DefineField(_O_, _fieldRecord_).
+        1. Let _elements_ be the value of _constructor_.[[Elements]].
+        1. Perform ? InitializePrivateMethods(_O_, _elements_).
+        1. For each element _initializer_ of _constructor_.[[Initializers]], do
+          1. Perform ? Call(_O_, _initializer_).
+        1. For each element _e_ of _elements_, do
+          1. If _elementRecord_.[[Kind]] is ~field~ or ~accessor~, then
+            1. Perform ? InitializeFieldOrAccessor(_O_, _elementRecord_).
         1. Return ~unused~.
       </emu-alg>
     </emu-clause>
@@ -7197,11 +7325,11 @@
       <emu-alg>
         1. Return « *"\*default\*"* ».
       </emu-alg>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : DecoratorList? `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Return the BoundNames of |BindingIdentifier|.
       </emu-alg>
-      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : DecoratorList? `class` ClassTail</emu-grammar>
       <emu-alg>
         1. Return « *"\*default\*"* ».
       </emu-alg>
@@ -7360,8 +7488,8 @@
       </emu-alg>
       <emu-grammar>
         ClassDeclaration :
-          `class` BindingIdentifier ClassTail
-          `class` ClassTail
+          DecoratorList? `class` BindingIdentifier ClassTail
+          DecoratorList? `class` ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -8778,7 +8906,7 @@
           CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody
 
         ClassExpression :
-          `class` ClassTail
+          DecoratorList? `class` ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *false*.
@@ -8797,7 +8925,7 @@
           `async` `function` BindingIdentifier `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         ClassExpression :
-          `class` BindingIdentifier ClassTail
+          DecoratorList? `class` BindingIdentifier ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -8938,7 +9066,7 @@
           `async` `function` BindingIdentifier? `(` FormalParameters `)` `{` AsyncFunctionBody `}`
 
         ClassExpression :
-          `class` BindingIdentifier? ClassTail
+          DecoratorList? `class` BindingIdentifier? ClassTail
       </emu-grammar>
       <emu-alg>
         1. Return *true*.
@@ -9057,9 +9185,12 @@
       <emu-alg>
         1. Return InstantiateAsyncArrowFunctionExpression of |AsyncArrowFunction| with argument _name_.
       </emu-alg>
-      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : DecoratorList? `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and _name_.
+        1. If |DecoratorList?| is present, then
+          1. Let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else, let _decorators_ be a new empty List.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined*, _name_, and _decorators_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
         1. Return _value_.
       </emu-alg>
@@ -9247,6 +9378,22 @@
         1. Let _inList_ be ComputedPropertyContains of |ClassElementList| with argument _symbol_.
         1. If _inList_ is *true*, return *true*.
         1. Return the result of ComputedPropertyContains of |ClassElement| with argument _symbol_.
+      </emu-alg>
+      <emu-grammar>
+        ClassElement :
+          DecoratorList? MethodDefinition
+          DecoratorList? `static` MethodDefinition
+      </emu-grammar>
+      <emu-alg>
+        1. Return ComputedPropertyContains of |MethodDefinition|.
+      </emu-alg>
+      <emu-grammar>
+        ClassElement :
+          DecoratorList? FieldDefinition `;`
+          DecoratorList? `static` FieldDefinition `;`
+      </emu-grammar>
+      <emu-alg>
+        1. Return ComputedPropertyContains of |FieldDefinition|.
       </emu-alg>
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
       <emu-alg>
@@ -9784,6 +9931,22 @@
       <emu-grammar>AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`</emu-grammar>
       <emu-alg>
         1. Return PropName of |ClassElementName|.
+      </emu-alg>
+      <emu-grammar>
+        ClassElement :
+          DecoratorList? MethodDefinition
+          DecoratorList? `static` MethodDefinition
+      </emu-grammar>
+      <emu-alg>
+        1. Return PropName of |MethodDefinition|.
+      </emu-alg>
+      <emu-grammar>
+        ClassElement :
+          DecoratorList? FieldDefinition `;`
+          DecoratorList? `static` FieldDefinition `;`
+      </emu-grammar>
+      <emu-alg>
+        1. Return PropName of |FieldDefinition|.
       </emu-alg>
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
       <emu-alg>
@@ -13011,24 +13174,24 @@
         </tr>
         <tr>
           <td>
-            [[Fields]]
+            [[Elements]]
           </td>
           <td>
-            a List of ClassFieldDefinition Records
+            a List of ClassElementDefinition Records
           </td>
           <td>
-            If the function is a class, this is a list of Records representing the non-static fields and corresponding initializers of the class.
+            If the function is a class, this is a list of Records representing the non-static elements and corresponding initializers of the class.
           </td>
         </tr>
         <tr>
           <td>
-            [[PrivateMethods]]
+            [[Initializers]]
           </td>
           <td>
-            a List of PrivateElements
+            a List of function objects | ~empty~
           </td>
           <td>
-            If the function is a class, this is a list representing the non-static private methods and accessors of the class.
+            If the function is a class with decorated prototype methods or accessors, this is a list of initializer functions added by the decorators, or ~empty~.
           </td>
         </tr>
         <tr>
@@ -13298,8 +13461,7 @@
         1. Set _F_.[[ScriptOrModule]] to GetActiveScriptOrModule().
         1. Set _F_.[[Realm]] to the current Realm Record.
         1. Set _F_.[[HomeObject]] to *undefined*.
-        1. Set _F_.[[Fields]] to a new empty List.
-        1. Set _F_.[[PrivateMethods]] to a new empty List.
+        1. Set _F_.[[Elements]] to a new empty List.
         1. Set _F_.[[ClassFieldInitializerName]] to ~empty~.
         1. Let _len_ be the ExpectedArgumentCount of _ParameterList_.
         1. Perform SetFunctionLength(_F_, _len_).
@@ -13403,21 +13565,23 @@
       <h1>
         DefineMethodProperty (
           _homeObject_: an Object,
-          _key_: a property key or Private Name,
-          _closure_: a function object,
+          _methodDefinition_: a ClassElementDefinition Record,
           _enumerable_: a Boolean,
-        ): a PrivateElement or ~unused~
+        ): either a normal completion containing ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
         1. Assert: _homeObject_ is an ordinary, extensible object with no non-configurable properties.
-        1. If _key_ is a Private Name, then
-          1. Return PrivateElement { [[Key]]: _key_, [[Kind]]: ~method~, [[Value]]: _closure_ }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Value]]: _closure_, [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ! DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
-          1. Return ~unused~.
+        1. Assert: _methodDefinition_.[[Kind]] is ~method~, ~getter~, ~setter~, or ~accessor~.
+        1. Let _key_ be _methodDefinition_.[[Key]].
+        1. If _key_ is not a Private Name, then
+          1. Let _desc_ be the PropertyDescriptor { [[Writable]]: *true*, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
+          1. If _methodDefinition_.[[Kind]] is ~getter~ or ~accessor~, set _desc_.[[Get]] to _methodDefinition_.[[Get]].
+          1. If _methodDefinition_.[[Kind]] is ~setter~ or ~accessor~, set _desc_.[[Set]] to _methodDefinition_.[[Set]].
+          1. If _methodDefinition_.[[Kind]] is ~method~, set _desc_.[[Value]] to _methodDefinition_.[[Value]].
+          1. Perform ? DefinePropertyOrThrow(_homeObject_, _key_, _desc_).
+        1. Return ~unused~.
       </emu-alg>
     </emu-clause>
 
@@ -18273,7 +18437,8 @@
         </emu-alg>
         <emu-grammar>PropertyDefinition : MethodDefinition</emu-grammar>
         <emu-alg>
-          1. Perform ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *true*.
+          1. Let _methodDefinition_ be ? MethodDefinitionEvaluation of |MethodDefinition| with argument _object_.
+          1. Perform ? DefineMethodProperty(_object_, _methodDefinition_, *true*).
           1. Return ~unused~.
         </emu-alg>
       </emu-clause>
@@ -23476,8 +23641,7 @@
       <h1>
         Runtime Semantics: MethodDefinitionEvaluation (
           _object_: an Object,
-          _enumerable_: a Boolean,
-        ): either a normal completion containing either a PrivateElement or ~unused~, or an abrupt completion
+        ): either a normal completion containing a ClassElementDefinition Record, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -23485,7 +23649,7 @@
       <emu-alg>
         1. Let _methodDef_ be ? DefineMethod of |MethodDefinition| with argument _object_.
         1. Perform SetFunctionName(_methodDef_.[[Closure]], _methodDef_.[[Key]]).
-        1. Return DefineMethodProperty(_object_, _methodDef_.[[Key]], _methodDef_.[[Closure]], _enumerable_).
+        1. Return ClassElementDefinition Record { [[Key]]: _methodDef_.[[Key]], [[Kind]]: ~method~, [[Value]]: _methodDef_.[[Closure]], [[Decorators]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>MethodDefinition : `get` ClassElementName `(` `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23497,12 +23661,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |FunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, *"get"*).
-        1. If _propKey_ is a Private Name, then
-          1. Return PrivateElement { [[Key]]: _propKey_, [[Kind]]: ~accessor~, [[Get]]: _closure_, [[Set]]: *undefined* }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Get]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-          1. Return ~unused~.
+        1. Return ClassElementDefinition Record { [[Key]]: _propKey_, [[Kind]]: ~getter~, [[Get]]: _closure_, [[Decorators]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>MethodDefinition : `set` ClassElementName `(` PropertySetParameterList `)` `{` FunctionBody `}`</emu-grammar>
       <emu-alg>
@@ -23513,12 +23672,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, |PropertySetParameterList|, |FunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_, *"set"*).
-        1. If _propKey_ is a Private Name, then
-          1. Return PrivateElement { [[Key]]: _propKey_, [[Kind]]: ~accessor~, [[Get]]: *undefined*, [[Set]]: _closure_ }.
-        1. Else,
-          1. Let _desc_ be the PropertyDescriptor { [[Set]]: _closure_, [[Enumerable]]: _enumerable_, [[Configurable]]: *true* }.
-          1. Perform ? DefinePropertyOrThrow(_object_, _propKey_, _desc_).
-          1. Return ~unused~.
+        1. Return ClassElementDefinition Record { [[Key]]: _propKey_, [[Kind]]: ~setter~, [[Set]]: _closure_, [[Decorators]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>GeneratorMethod : `*` ClassElementName `(` UniqueFormalParameters `)` `{` GeneratorBody `}`</emu-grammar>
       <emu-alg>
@@ -23531,7 +23685,7 @@
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return ClassElementDefinition Record { [[Key]]: _propKey_, [[Kind]]: ~method~, [[Value]]: _closure_, [[Decorators]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>
         AsyncGeneratorMethod : `async` `*` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncGeneratorBody `}`
@@ -23546,7 +23700,7 @@
         1. Perform SetFunctionName(_closure_, _propKey_).
         1. Let _prototype_ be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
         1. Perform ! DefinePropertyOrThrow(_closure_, *"prototype"*, PropertyDescriptor { [[Value]]: _prototype_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *false* }).
-        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return ClassElementDefinition Record { [[Key]]: _propKey_, [[Kind]]: ~method~, [[Value]]: _closure_, [[Decorators]]: ~empty~ }.
       </emu-alg>
       <emu-grammar>
         AsyncMethod : `async` ClassElementName `(` UniqueFormalParameters `)` `{` AsyncFunctionBody `}`
@@ -23559,7 +23713,7 @@
         1. Let _closure_ be OrdinaryFunctionCreate(%AsyncFunction.prototype%, _sourceText_, |UniqueFormalParameters|, |AsyncFunctionBody|, ~non-lexical-this~, _env_, _privateEnv_).
         1. Perform MakeMethod(_closure_, _object_).
         1. Perform SetFunctionName(_closure_, _propKey_).
-        1. Return DefineMethodProperty(_object_, _propKey_, _closure_, _enumerable_).
+        1. Return ClassElementDefinition Record { [[Key]]: _propKey_, [[Kind]]: ~method~, [[Value]]: _closure_, [[Decorators]]: ~empty~ }.
       </emu-alg>
     </emu-clause>
   </emu-clause>
@@ -23991,16 +24145,272 @@
     </emu-clause>
   </emu-clause>
 
+  <emu-clause id="sec-decorators">
+    <h1>Decorators</h1>
+    <h2>Syntax</h2>
+    <emu-grammar type="definition">
+      DecoratorList[Yield, Await] :
+        DecoratorList[?Yield, ?Await]? Decorator[?Yield, ?Await]
+
+      Decorator[Yield, Await] :
+        `@` DecoratorMemberExpression[?Yield, ?Await]
+        `@` DecoratorParenthesizedExpression[?Yield, ?Await]
+        `@` DecoratorCallExpression[?Yield, ?Await]
+
+      DecoratorMemberExpression[Yield, Await] :
+        IdentifierReference[?Yield, ?Await]
+        PrivateIdentifier
+        DecoratorMemberExpression[?Yield, ?Await] `.` IdentifierName
+
+      DecoratorParenthesizedExpression[Yield, Await] :
+        `(` Expression[+In, ?Yield, ?Await] `)`
+
+      DecoratorCallExpression[Yield, Await] :
+        DecoratorMemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
+    </emu-grammar>
+
+    <emu-clause id="sec-decoratorevaluation" type="sdo">
+      <h1>Runtime Semantics: DecoratorEvaluation ( ): either a normal completion containing an ECMAScript language value or an abrupt completion</h1>
+      <dl class="header">
+      </dl>
+      <emu-grammar>Decorator : `@` DecoratorMemberExpression</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be the |MemberExpression| that is covered by |DecoratorMemberExpression|.
+        1. Let _ref_ be the result of evaluating _expr_.
+        1. Return ? GetValue(_ref_).
+      </emu-alg>
+      <emu-grammar>Decorator : `@` DecoratorCallExpression</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be the |CallMemberExpression| that is covered by |DecoratorCallExpression|.
+        1. Let _ref_ be the result of evaluating _expr_.
+        1. Return ? GetValue(_ref_).
+      </emu-alg>
+      <emu-grammar>Decorator : `@` DecoratorParenthesizedExpression</emu-grammar>
+      <emu-alg>
+        1. Let _expr_ be the |MemberExpression| that is covered by |DecoratorParenthesizedExpression|.
+        1. Let _ref_ be the result of evaluating _expr_.
+        1. Return ? GetValue(_ref_).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-decoratorlistevaluation" type="sdo">
+      <h1>Runtime Semantics: DecoratorListEvaluation ( ): either a normal completion containing a List of ECMAScript language values or an abrupt completion</h1>
+      <dl class="header">
+      </dl>
+      <emu-grammar>DecoratorList : DecoratorList? Decorator</emu-grammar>
+      <emu-alg>
+        1. If |DecoratorList| is present, then
+          1. Let _leftValue_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else,
+          1. Let _leftValue_ be a new empty List.
+        1. Let _rightValue_ be ? DecoratorEvaluation of |Decorator|.
+        1. Prepend _rightValue_ to _leftValue_.
+        1. Return _leftValue_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-createdecoratoraccessobject" type="abstract operation">
+      <h1>
+        CreateDecoratorAccessObject (
+          _kind_: ~field~, ~method~, ~accessor~, ~getter~, or ~setter~,
+          _name_: either a String, a Symbol, or a Private Name,
+        ): an Object
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>Returns an object with appropriate accessor functions for the value, for use in a decorator context object.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _accessObj_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. If _kind_ is ~field~, ~method~, ~accessor~, or ~getter~, then
+          1. Let _getterClosure_ be a new Abstract Closure with parameter (_obj_) that captures _name_ and performs the following steps when called:
+            1. If _obj_ is not an Object, throw a *TypeError* exception.
+            1. If _name_ is either a String or a Symbol, return ? Get(_obj_, _name_).
+            1. Else, return ? PrivateGet(_name_, _obj_).
+          1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 1, *""*, &laquo; &raquo;).
+          1. Perform ! CreateDataPropertyOrThrow(_accessObj_, *"get"*, _getter_).
+        1. If _kind_ is ~field~, ~accessor~, or ~setter~, then
+          1. Let _setterClosure_ be a new Abstract Closure with parameters (_obj_, _value_) that captures _name_ and performs the following steps when called:
+            1. If _obj_ is not an Object, throw a *TypeError* exception.
+            1. If _name_ is either a String or a Symbol, perform ? Set(_obj_, _name_, _value_, *true*).
+            1. Else, perform ? PrivateSet(_name_, _obj_, _value_).
+            1. Return *undefined*.
+          1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 2, *""*, &laquo; &raquo;).
+          1. Perform ! CreateDataPropertyOrThrow(_accessObj_, *"set"*, _setter_).
+        1. Let _hasClosure_ be a new Abstract Closure with parameter (_obj_) that captures _name_ and performs the following steps when called:
+          1. If _obj_ is not an Object, throw a *TypeError* exception.
+          1. If _name_ is either a String or a Symbol, return ? HasProperty(_obj_, _name_).
+          1. If PrivateElementFind(_obj_, _name_) is not ~empty~, return *true*.
+          1. Return *false*.
+        1. Let _has_ be CreateBuiltinFunction(_hasClosure_, 1, *""*, &laquo; &raquo;).
+        1. Perform ! CreateDataPropertyOrThrow(_accessObj_, *"has"*, _has_).
+        1. Return _accessObj_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-createaddinitializerfunction" type="abstract operation">
+      <h1>
+        CreateAddInitializerFunction (
+          _initializers_: a List of ECMAScript function objects,
+          _decorationState_: a Record with a field [[Finished]] (a Boolean),
+        ): a function object
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>Creates a function for a decorator's context object which can be used to add an extra initializer to the class.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _addInitializerClosure_ be a new Abstract Closure with parameters (_initializer_) that captures _initializers_ and _decorationState_ and performs the following steps when called:
+          1. If _decorationState_.[[Finished]] is *true*, throw a *TypeError* exception.
+          1. Append _initializer_ to _initializers_.
+          1. Return *undefined*.
+        1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *""*, &laquo; &raquo;).
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-createdecoratorcontextobject" type="abstract operation">
+      <h1>
+        CreateDecoratorContextObject (
+          _kind_: ~class~, ~field~, ~method~, ~accessor~, ~getter~, or ~setter~,
+          _name_: a String, a Symbol, or Private Name,
+          _initializers_: a List of function objects,
+          _decorationState_: a Record with a field [[Finished]] (a Boolean),
+          optional _isStatic_: a Boolean,
+        ): an Object
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It returns a context object which is passed as the second argument to decorators of the given class element.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _contextObj_ be OrdinaryObjectCreate(%Object.prototype%).
+        1. If _kind_ is ~method~, let _kindStr_ be *"method"*.
+        1. Else if _kind_ is ~getter~, let _kindStr_ be *"getter"*.
+        1. Else if _kind_ is ~setter~, let _kindStr_ be *"setter"*.
+        1. Else if _kind_ is ~accessor~, let _kindStr_ be *"accessor"*.
+        1. Else if _kind_ is ~field~, let _kindStr_ be *"field"*.
+        1. Else,
+          1. Assert: _kind_ is ~class~.
+          1. Let _kindStr_ be *"class"*.
+        1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"kind"*, _kindStr_).
+        1. If _kind_ is not ~class~, then
+          1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"access"*, CreateDecoratorAccessObject(_kind_, _name_)).
+          1. If _isStatic_ is present, perform ! CreateDataPropertyOrThrow(_contextObj_, *"static"*, _isStatic_).
+          1. If _name_ is a Private Name, then
+            1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"private"*, *true*).
+            1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"name"*, _name_.[[Description]]).
+          1. Else,
+            1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"private"*, *false*).
+            1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"name"*, _name_).
+        1. Else,
+          1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"name"*, _name_).
+        1. Let _addInitializer_ be CreateAddInitializerFunction(_initializers_, _decorationState_).
+        1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"addInitializer"*, _addInitializer_).
+        1. Return _contextObj_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-applydecoratorstoelementdefinition" type="abstract operation">
+      <h1>
+        ApplyDecoratorsToElementDefinition (
+          _homeObject_: an Object,
+          _elementRecord_: a ClassElementDefinition Record,
+          _extraInitializers_: a List of function objects,
+          _isStatic_: a Boolean,
+        ): either a normal completion containing ~unused~, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>Applies the decorators stored on an ClassElementDefinition to the value of the definition.</dd>
+      </dl>
+      <emu-alg>
+        1. Let _decorators_ be _elementRecord_.[[Decorators]].
+        1. If _decorators_ is ~empty~, return ~unused~.
+        1. Let _key_ be _elementRecord_.[[Key]].
+        1. Let _kind_ be _elementRecord_.[[Kind]].
+        1. For each element _decorator_ of _decorators_, do
+          1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
+          1. Let _context_ be CreateDecoratorContextObject(_kind_, _key_, _extraInitializers_, _decorationState_, _isStatic_).
+          1. Let _value_ be *undefined*.
+          1. If _kind_ is ~method~, set _value_ to _elementRecord_.[[Value]].
+          1. Else if _kind_ is ~getter~, set _value_ to _elementRecord_.[[Get]].
+          1. Else if _kind_ is ~setter~, set _value_ to _elementRecord_.[[Set]].
+          1. Else if _kind_ is ~accessor~, then
+            1. Set _value_ to OrdinaryObjectCreate(%Object.prototype%).
+            1. Perform ! CreateDataPropertyOrThrow(_accessor_, *"get"*, _elementRecord_.[[Get]]).
+            1. Perform ! CreateDataPropertyOrThrow(_accessor_, *"set"*, _elementRecord_.[[Set]]).
+          1. Let _newValue_ be ? Call(_decorator_, *undefined*, &laquo; _value_, _context_ &raquo;).
+          1. Set _decorationState_.[[Finished]] to *true*.
+          1. If _kind_ is ~field~, then
+            1. If IsCallable(_initializer_) is *true*, append _initializer_ to _elementRecord_.[[Initializers]].
+            1. Else if _initializer_ is not *undefined*, throw a *TypeError* exception.
+          1. Else if _kind_ is ~accessor~, then
+            1. If _newValue_ is an Object, then
+              1. Let _newGetter_ be ? Get(_newValue_, *"get"*).
+              1. If IsCallable(_newGetter_) is *true*, set _elementRecord_.[[Get]] to _newGetter_.
+              1. Else if _newGetter_ is not *undefined*, throw a *TypeError* exception.
+              1. Let _newSetter_ be ? Get(_newValue_, *"set"*).
+              1. If IsCallable(_newSetter_) is *true*, set _elementRecord_.[[Set]] to _newSetter_.
+              1. Else if _newSetter_ is not *undefined*, throw a *TypeError* exception.
+              1. Let _initializer_ be ? Get(_newValue_, *"init"*).
+              1. If IsCallable(_initializer_) is *true*, append _initializer_ to _elementRecord_.[[Initializers]].
+              1. Else if _initializer_ is not *undefined*, throw a *TypeError* exception.
+            1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
+          1. Else,
+            1. If IsCallable(_newValue_) is *true*, then
+              1. Perform MakeMethod(_newValue_, _homeObject_).
+              1. If _kind_ is ~getter~, then
+                1. Perform SetFunctionName(_newValue_, _key_, *"get"*).
+                1. Set _elementRecord_.[[Get]] to _newValue_.
+              1. Else if _kind_ is ~setter~, then
+                1. Perform SetFunctionName(_newValue_, _key_, *"set"*).
+                1. Set _elementRecord_.[[Set]] to _newValue_.
+              1. Else,
+                1. Perform SetFunctionName(_newValue_, _key_).
+                1. Set _elementRecord_.[[Value]] to _newValue_.
+            1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.
+        1. Set _elementRecord_.[[Decorators]] to ~empty~.
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-applydecoratorstoclassdefinition" type="abstract operation">
+      <h1>
+        ApplyDecoratorsToClassDefinition (
+          _classDef_: a function object,
+          _decorators_: a List of function objects,
+          _extraInitializers_: a List of function objects,
+        ): either a normal completion containing a function object, or an abrupt completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>Applies the passed decorators to the passed class definition.</dd>
+      </dl>
+      <emu-alg>
+        1. For each element _decorator_ of _decorators_, do
+          1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
+          1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _classExtraInitializers_, _decorationState_).
+          1. Let _newDef_ be ? Call(_decorator_, *undefined*, &laquo; _classDef_, _context_ &raquo;).
+          1. Set _decorationState_.[[Finished]] to *true*.
+          1. If IsCallable(_newDef_) is *true*, then
+            1. Set _classDef_ to _newDef_.
+          1. Else if _newDef_ is not *undefined*, then
+            1. Throw a *TypeError* exception.
+        1. Return _classDef_.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
   <emu-clause id="sec-class-definitions">
     <h1>Class Definitions</h1>
     <h2>Syntax</h2>
     <emu-grammar type="definition">
       ClassDeclaration[Yield, Await, Default] :
-        `class` BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
-        [+Default] `class` ClassTail[?Yield, ?Await]
+        DecoratorList[?Yield, ?Await]? `class` BindingIdentifier[?Yield, ?Await] ClassTail[?Yield, ?Await]
+        [+Default] DecoratorList[?Yield, ?Await]? `class` ClassTail[?Yield, ?Await]
 
       ClassExpression[Yield, Await] :
-        `class` BindingIdentifier[?Yield, ?Await]? ClassTail[?Yield, ?Await]
+        DecoratorList[?Yield, ?Await]? `class` BindingIdentifier[?Yield, ?Await]? ClassTail[?Yield, ?Await]
 
       ClassTail[Yield, Await] :
         ClassHeritage[?Yield, ?Await]? `{` ClassBody[?Yield, ?Await]? `}`
@@ -24016,15 +24426,16 @@
         ClassElementList[?Yield, ?Await] ClassElement[?Yield, ?Await]
 
       ClassElement[Yield, Await] :
-        MethodDefinition[?Yield, ?Await]
-        `static` MethodDefinition[?Yield, ?Await]
-        FieldDefinition[?Yield, ?Await] `;`
-        `static` FieldDefinition[?Yield, ?Await] `;`
+        DecoratorList[?Yield, ?Await]? MethodDefinition[?Yield, ?Await]
+        DecoratorList[?Yield, ?Await]? `static` MethodDefinition[?Yield, ?Await]
+        DecoratorList[?Yield, ?Await]? FieldDefinition[?Yield, ?Await] `;`
+        DecoratorList[?Yield, ?Await]? `static` FieldDefinition[?Yield, ?Await] `;`
         ClassStaticBlock
         `;`
 
       FieldDefinition[Yield, Await] :
         ClassElementName[?Yield, ?Await] Initializer[+In, ?Yield, ?Await]?
+        `accessor` [no LineTerminator here] ClassElementName[?Yield, ?Await] Initializer[+In, ?Yield, ?Await]?
 
       ClassElementName[Yield, Await] :
         PropertyName[?Yield, ?Await]
@@ -24065,7 +24476,7 @@
           It is a Syntax Error if PrivateBoundIdentifiers of |ClassElementList| contains any duplicate entries, unless the name is used once for a getter and once for a setter and in no other entries, and the getter and setter are either both static or both non-static.
         </li>
       </ul>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? MethodDefinition</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if PropName of |MethodDefinition| is not *"constructor"* and HasDirectSuper of |MethodDefinition| is *true*.
@@ -24074,7 +24485,7 @@
           It is a Syntax Error if PropName of |MethodDefinition| is *"constructor"* and SpecialMethod of |MethodDefinition| is *true*.
         </li>
       </ul>
-      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? `static` MethodDefinition</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if HasDirectSuper of |MethodDefinition| is *true*.
@@ -24084,12 +24495,12 @@
         </li>
       </ul>
 
-      <emu-grammar>ClassElement : FieldDefinition `;`</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? FieldDefinition `;`</emu-grammar>
       <ul>
         <li>It is a Syntax Error if PropName of |FieldDefinition| is *"constructor"*.</li>
       </ul>
 
-      <emu-grammar>ClassElement : `static` FieldDefinition `;`</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? `static` FieldDefinition `;`</emu-grammar>
       <ul>
         <li>
           It is a Syntax Error if PropName of |FieldDefinition| is either *"prototype"* or *"constructor"*.
@@ -24099,6 +24510,7 @@
       <emu-grammar>
         FieldDefinition :
           ClassElementName Initializer?
+          `accessor` ClassElementName Initializer?
       </emu-grammar>
       <ul>
         <li>It is a Syntax Error if |Initializer| is present and ContainsArguments of |Initializer| is *true*.</li>
@@ -24143,16 +24555,16 @@
       <h1>Static Semantics: ClassElementKind ( ): ~ConstructorMethod~, ~NonConstructorMethod~, or ~empty~</h1>
       <dl class="header">
       </dl>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? MethodDefinition</emu-grammar>
       <emu-alg>
         1. If PropName of |MethodDefinition| is *"constructor"*, return ~ConstructorMethod~.
         1. Return ~NonConstructorMethod~.
       </emu-alg>
       <emu-grammar>
         ClassElement :
-          `static` MethodDefinition
-          FieldDefinition `;`
-          `static` FieldDefinition `;`
+          DecoratorList? `static` MethodDefinition
+          DecoratorList? FieldDefinition `;`
+          DecoratorList? `static` FieldDefinition `;`
       </emu-grammar>
       <emu-alg>
         1. Return ~NonConstructorMethod~.
@@ -24192,19 +24604,19 @@
       <h1>Static Semantics: IsStatic ( ): a Boolean</h1>
       <dl class="header">
       </dl>
-      <emu-grammar>ClassElement : MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>ClassElement : `static` MethodDefinition</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? `static` MethodDefinition</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
-      <emu-grammar>ClassElement : FieldDefinition `;`</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? FieldDefinition `;`</emu-grammar>
       <emu-alg>
         1. Return *false*.
       </emu-alg>
-      <emu-grammar>ClassElement : `static` FieldDefinition `;`</emu-grammar>
+      <emu-grammar>ClassElement : DecoratorList? `static` FieldDefinition `;`</emu-grammar>
       <emu-alg>
         1. Return *true*.
       </emu-alg>
@@ -24334,6 +24746,23 @@
       </emu-alg>
 
       <emu-grammar>
+        ClassElement :
+          DecoratorList? MethodDefinition
+          DecoratorList? `static` MethodDefinition
+      </emu-grammar>
+      <emu-alg>
+        1. Return PrivateBoundIdentifiers of |MethodDefinition|.
+      </emu-alg>
+      <emu-grammar>
+        ClassElement :
+          DecoratorList? FieldDefinition `;`
+          DecoratorList? `static` FieldDefinition `;`
+      </emu-grammar>
+      <emu-alg>
+        1. Return PrivateBoundIdentifiers of |FieldDefinition|.
+      </emu-alg>
+
+      <emu-grammar>
         ClassElementName :
           PropertyName
 
@@ -24448,11 +24877,104 @@
       </emu-alg>
     </emu-clause>
 
+    <emu-clause id="sec-class-definitions-static-semantics-methoddecorators">
+      <h1>Static Semantics: Method Decorators</h1>
+      <emu-grammar>
+        ClassElement : DecoratorList? MethodDefinition
+      </emu-grammar>
+      <ul>
+        <li>
+          It is a Syntax Error if |DecoratorList| is present and PropName of |MethodDefinition| is `"constructor"`.
+        </li>
+      </ul>
+    </emu-clause>
+
+    <emu-clause id="sec-applydecoratorsanddefinemethod" type="abstract operation">
+      <h1>
+        ApplyDecoratorsAndDefineMethod (
+          _homeObject_: an Object,
+          _methodDefinition_: a ClassElementDefinition record,
+          _extraInitializers_: A List of function objects,
+          _isStatic_: a Boolean,
+        ): either a normal completion containing ~unused~, or an abrupt completion
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Perform ? ApplyDecoratorsToElementDefinition(_homeObject_, _methodDefinition_, _extraInitializers_, _isStatic_).
+        1. Perform ? DefineMethodProperty(_homeObject_, _methodDefinition_, _isStatic_).
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-createfieldinitializerfunction" type="abstract operation">
+      <h1>
+        CreateFieldInitializerFunction (
+          _homeObject_: an Object,
+          _propName_: a property key or Private Name,
+          _Initializer_: a function object,
+        ): a function object
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
+        1. Let _scope_ be the LexicalEnvironment of the running execution context.
+        1. Let _privateScope_ be the running execution context's PrivateEnvironment.
+        1. Let _sourceText_ be the empty sequence of Unicode code points.
+        1. Let _initializer_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, _Initializer_, ~non-lexical-this~, _scope_, _privateScope_).
+        1. Perform MakeMethod(_initializer_, _homeObject_).
+        1. Set _initializer_.[[ClassFieldInitializerName]] to _propName_.
+        1. Return _initializer_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-makeautoaccessorgetter" type="abstract operation">
+      <h1>
+        MakeAutoAccessorGetter (
+          _homeObject_: an Object,
+          _name_: a property key or Private Name,
+          _privateStateName_: a Private Name,
+        ): a function object
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _getterClosure_ be a new Abstract Closure with no parameters that captures _privateStateName_ and performs the following steps when called:
+          1. Let _o_ be the *this* value.
+          1. Return ? PrivateGet(_privateStateName_, _o_).
+        1. Let _getter_ be CreateBuiltinFunction(_getterClosure_, 0, *"get"*, &laquo; &raquo;).
+        1. Perform MakeMethod(_getter_, _homeObject_).
+        1. Return _getter_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-makeautoaccessorsetter" type="abstract operation">
+      <h1>
+        MakeAutoAccessorSetter (
+          _homeObject_: an Object,
+          _name_: a property key or Private Name,
+          _privateStateName_: a Private Name,
+        ): a function object
+      </h1>
+      <dl class="header">
+      </dl>
+      <emu-alg>
+        1. Let _setterClosure_ be a new Abstract Closure with parameters (_value_) that captures _privateStateName_ and performs the following steps when called:
+          1. Let _o_ be the *this* value.
+          1. Perform ? PrivateSet(_privateStateName_, _o_, _value_).
+          1. Return *undefined*.
+        1. Let _setter_ be CreateBuiltinFunction(_setterClosure_, 1, *"set"*, &laquo; &raquo;).
+        1. Perform MakeMethod(_setter_, _homeObject_).
+        1. Return _setter_.
+      </emu-alg>
+    </emu-clause>
+
     <emu-clause id="sec-runtime-semantics-classfielddefinitionevaluation" type="sdo">
       <h1>
         Runtime Semantics: ClassFieldDefinitionEvaluation (
           _homeObject_: an Object,
-        ): either a normal completion containing a ClassFieldDefinition Record or an abrupt completion
+        ): either a normal completion containing a ClassElementDefinition Record or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
@@ -24461,17 +24983,30 @@
       </emu-grammar>
       <emu-alg>
         1. Let _name_ be ? Evaluation of |ClassElementName|.
+        1. Let _initializers_ be a new empty List.
         1. If |Initializer?| is present, then
-          1. Let _formalParameterList_ be an instance of the production <emu-grammar>FormalParameters : [empty]</emu-grammar>.
-          1. Let _env_ be the LexicalEnvironment of the running execution context.
-          1. Let _privateEnv_ be the running execution context's PrivateEnvironment.
-          1. Let _sourceText_ be the empty sequence of Unicode code points.
-          1. Let _initializer_ be OrdinaryFunctionCreate(%Function.prototype%, _sourceText_, _formalParameterList_, |Initializer|, ~non-lexical-this~, _env_, _privateEnv_).
-          1. Perform MakeMethod(_initializer_, _homeObject_).
-          1. Set _initializer_.[[ClassFieldInitializerName]] to _name_.
-        1. Else,
-          1. Let _initializer_ be ~empty~.
-        1. Return the ClassFieldDefinition Record { [[Name]]: _name_, [[Initializer]]: _initializer_ }.
+          1. Let _initializer_ be CreateFieldInitializerFunction(_homeObject_, _name_, |Initializer|).
+          1. Append _initializer_ to _initializers_.
+        1. Return ClassElementDefinition Record { [[Key]]: _name_, [[Kind]]: ~field~, [[Initializers]]: _initializers_, [[Decorators]]: ~empty~ }.
+      </emu-alg>
+      <emu-grammar>
+        FieldDefinition : `accessor` ClassElementName Initializer?
+      </emu-grammar>
+      <emu-alg>
+        1. Let _name_ be the result of evaluating |ClassElementName|.
+        1. ReturnIfAbrupt(_name_).
+        1. Let _privateStateDesc_ be the string-concatenation of _name_ and *" accessor storage"*.
+        1. Let _privateStateName_ be a new Private Name whose [[Description]] value is _privateStateDesc_.
+        1. Let _getter_ be MakeAutoAccessorGetter(_homeObject_, _name_, _privateStateName_).
+        1. Let _setter_ be MakeAutoAccessorSetter(_homeObject_, _name_, _privateStateName_).
+        1. Let _initializers_ be a new empty List.
+        1. If |Initializer?| is present, then
+          1. Let _initializer_ be CreateFieldInitializerFunction(_homeObject_, _name_, |Initializer|).
+          1. Append _initializer_ to _initializers_.
+        1. If _name_ is not a Private Name, then
+          1. Let _desc_ be the PropertyDescriptor { [[Get]]: _getter_, [[Set]]: _setter_, [[Enumerable]]: *true*, [[Configurable]]: *true* }.
+          1. Perform ? DefinePropertyOrThrow(_homeObject_, _name_, _desc_).
+        1. Return ClassElementDefinition Record { [[Key]]: _name_, [[Kind]]: ~accessor~, [[Get]]: _getter_, [[Set]]: _setter_, [[BackingStorageKey]]: _privateStateName_, [[Initializers]]: _initializers_, [[Decorators]]: ~empty~ }.
       </emu-alg>
       <emu-note>
         The function created for _initializer_ is never directly accessible to ECMAScript code.
@@ -24518,27 +25053,34 @@
       <h1>
         Runtime Semantics: ClassElementEvaluation (
           _object_: an Object,
-        ): either a normal completion containing either a ClassFieldDefinition Record, a ClassStaticBlockDefinition Record, a PrivateElement, or ~unused~, or an abrupt completion
+        ): either a normal completion containing either a ClassElementDefinition Record, a ClassStaticBlockDefinition Record, or ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
-
       <emu-grammar>
         ClassElement :
-          FieldDefinition `;`
-          `static` FieldDefinition `;`
+          DecoratorList? FieldDefinition `;`
+          DecoratorList? `static` FieldDefinition `;`
       </emu-grammar>
       <emu-alg>
-        1. Return ? ClassFieldDefinitionEvaluation of |FieldDefinition| with argument _object_.
+        1. If |DecoratorList?| is present, let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else, let _decorators_ be a new empty List.
+        1. Let _fieldDefinition_ be ? ClassFieldDefinitionEvaluation of |FieldDefinition| with argument _object_.
+        1. Set _fieldDefinition_.[[Decorators]] to _decorators_.
+        1. Return _fieldDefinition_.
       </emu-alg>
 
       <emu-grammar>
         ClassElement :
-          MethodDefinition
-          `static` MethodDefinition
+          DecoratorList? MethodDefinition
+          DecoratorList? `static` MethodDefinition
       </emu-grammar>
       <emu-alg>
-        1. Return ? MethodDefinitionEvaluation of |MethodDefinition| with arguments _object_ and *false*.
+        1. If |DecoratorList?| is present, let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else, let _decorators_ be a new empty List.
+        1. Let _methodDefinition_ be ? MethodDefinitionEvaluation of |MethodDefinition| with argument _object_.
+        1. Set _methodDefinition_.[[Decorators]] to _decorators_.
+        1. Return _methodDefinition_.
       </emu-alg>
 
       <emu-grammar>ClassElement : ClassStaticBlock</emu-grammar>
@@ -24559,6 +25101,7 @@
         Runtime Semantics: ClassDefinitionEvaluation (
           _classBinding_: a String or *undefined*,
           _className_: a property key or a Private Name,
+          _decorators_: a List of function objects,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
@@ -24631,51 +25174,76 @@
         1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
         1. If |ClassBody?| is not present, let _elements_ be a new empty List.
         1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
-        1. Let _instancePrivateMethods_ be a new empty List.
-        1. Let _staticPrivateMethods_ be a new empty List.
-        1. Let _instanceFields_ be a new empty List.
+        1. Let _instanceElements_ be a new empty List.
         1. Let _staticElements_ be a new empty List.
         1. For each |ClassElement| _e_ of _elements_, do
-          1. If IsStatic of _e_ is *false*, then
-            1. Let _element_ be Completion(ClassElementEvaluation of _e_ with argument _proto_).
-          1. Else,
-            1. Let _element_ be Completion(ClassElementEvaluation of _e_ with argument _F_).
-          1. If _element_ is an abrupt completion, then
+          1. If IsStatic of _e_ is *false*, let _result_ be Completion(ClassElementEvaluation of _e_ with argument _proto_).
+          1. Else, let _result_ be Completion(ClassElementEvaluation of _e_ with argument _F_).
+          1. If _result_ is an abrupt completion, then
             1. Set the running execution context's LexicalEnvironment to _env_.
             1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
-            1. Return ? _element_.
-          1. Set _element_ to _element_.[[Value]].
-          1. If _element_ is a PrivateElement, then
-            1. Assert: _element_.[[Kind]] is either ~method~ or ~accessor~.
-            1. If IsStatic of _e_ is *false*, let _container_ be _instancePrivateMethods_.
-            1. Else, let _container_ be _staticPrivateMethods_.
-            1. If _container_ contains a PrivateElement _pe_ such that _pe_.[[Key]] is _element_.[[Key]], then
-              1. Assert: _element_.[[Kind]] and _pe_.[[Kind]] are both ~accessor~.
-              1. If _element_.[[Get]] is *undefined*, then
-                1. Let _combined_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _pe_.[[Get]], [[Set]]: _element_.[[Set]] }.
-              1. Else,
-                1. Let _combined_ be PrivateElement { [[Key]]: _element_.[[Key]], [[Kind]]: ~accessor~, [[Get]]: _element_.[[Get]], [[Set]]: _pe_.[[Set]] }.
-              1. Replace _pe_ in _container_ with _combined_.
-            1. Else,
-              1. Append _element_ to _container_.
-          1. Else if _element_ is a ClassFieldDefinition Record, then
-            1. If IsStatic of _e_ is *false*, append _element_ to _instanceFields_.
+            1. Return ? _result_.
+          1. Let _element_ be _result_.[[Value]].
+          1. If _element_ is a ClassElementDefinition Record, then
+            1. If IsStatic of _e_ is *false*, append _element_ to _instanceElements_.
             1. Else, append _element_ to _staticElements_.
-          1. Else if _element_ is a ClassStaticBlockDefinition Record, then
+          1. Else,
+            1. Assert: _element_ is a ClassStaticBlockDefinition Record.
             1. Append _element_ to _staticElements_.
         1. Set the running execution context's LexicalEnvironment to _env_.
-        1. If _classBinding_ is not *undefined*, then
-          1. Perform ! _classEnv_.InitializeBinding(_classBinding_, _F_).
-        1. Set _F_.[[PrivateMethods]] to _instancePrivateMethods_.
-        1. Set _F_.[[Fields]] to _instanceFields_.
+        1. Let _instanceExtraInitializers_ be a new empty List.
+        1. Let _staticExtraInitializers_ be a new empty List.
+        1. For each element _e_ of _staticElements_, do
+          1. If _e_.[[Kind]] is not ~field~, then
+            1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_F_, _e_, _staticExtraInitializers_, *true*)).
+            1. If _result_ is an abrupt completion, then
+              1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+              1. Return ? _result_.
+        1. For each element _e_ of _instanceElements_, do
+          1. If _e_.[[Kind]] is not ~field~, then
+            1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_proto_, _e_, _instanceExtraInitializers_, *true*)).
+            1. If _result_ is an abrupt completion, then
+              1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+              1. Return ? _result_.
+        1. For each element _e_ of _staticElements_, do
+          1. If _e_.[[Kind]] is ~field~, then
+            1. Let _result_ be Completion(ApplyDecoratorsToElementDefinition(_F_, _e_, _staticExtraInitializers_, *true*)).
+            1. If _result_ is an abrupt completion, then
+              1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+              1. Return ? _result_.
+        1. For each element _e_ of _instanceElements_, do
+          1. If _e_.[[Kind]] is ~field~, then
+            1. Let _result_ be Completion(ApplyDecoratorsToElementDefinition(_proto_, _e_, _instanceExtraInitializers_, *false*)).
+            1. If _result_ is an abrupt completion, then
+              1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+              1. Return ? _result_.
+        1. Set _F_.[[Elements]] to _instanceElements_.
+        1. Set _F_.[[Initializers]] to _instanceExtraInitializers_.
         1. For each PrivateElement _method_ of _staticPrivateMethods_, do
           1. Perform ! PrivateMethodOrAccessorAdd(_F_, _method_).
+        1. Let _classExtraInitializers_ be a new empty List.
+        1. Let _newF_ be Completion(ApplyDecoratorsToClassDefinition(_F_, _decorators_, _classExtraInitializers_)).
+        1. If _newF_ is an abrupt completion, then
+          1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+          1. Return ? _result_.
+        1. Set _F_ to _newF_.[[Value]].
+        1. If _classBinding_ is not *undefined*, then
+          1. Perform _classScope_.InitializeBinding(_classBinding_, _F_).
+        1. For each element _initializer_ of _staticExtraInitializers_, do
+          1. Let _result_ be Completion(Call(_initializer_, _F_)).
+          1. If _result_ is an abrupt completion, then
+            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+            1. Return ? _result_.
         1. For each element _elementRecord_ of _staticElements_, do
-          1. If _elementRecord_ is a ClassFieldDefinition Record, then
-            1. Let _result_ be Completion(DefineField(_F_, _elementRecord_)).
-          1. Else,
-            1. Assert: _elementRecord_ is a ClassStaticBlockDefinition Record.
+          1. If _elementRecord_ is a ClassElementDefinition Record and _elementRecord_.[[Kind]] is ~field~ or ~accessor~, then
+            1. Let _result_ be Completion(InitializeFieldOrAccessor(_F_, _elementRecord_)).
+          1. Else if _elementRecord_ is a ClassStaticBlockDefinition Record, then
             1. Let _result_ be Completion(Call(_elementRecord_.[[BodyFunction]], _F_)).
+          1. If _result_ is an abrupt completion, then
+            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+            1. Return ? _result_.
+        1. For each element _initializer_ of _classExtraInitializers_, do
+          1. Let _result_ be Completion(Call(_initializer_, _F_)).
           1. If _result_ is an abrupt completion, then
             1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
             1. Return ? _result_.
@@ -24685,49 +25253,62 @@
     </emu-clause>
 
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo">
-      <h1>Runtime Semantics: BindingClassDeclarationEvaluation ( ): either a normal completion containing a function object or an abrupt completion</h1>
+      <h1>
+        Runtime Semantics: BindingClassDeclarationEvaluation (
+          _decorators_: a List,
+        ): either a normal completion containing a function object or an abrupt completion
+      </h1>
       <dl class="header">
       </dl>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : DecoratorList? `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be StringValue of |BindingIdentifier|.
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _decorators_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
         1. Let _env_ be the running execution context's LexicalEnvironment.
         1. Perform ? InitializeBoundName(_className_, _value_, _env_).
         1. Return _value_.
       </emu-alg>
-      <emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : DecoratorList? `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and *"default"*.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined*, *"default"*, and _decorators_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassDeclaration|.
         1. Return _value_.
       </emu-alg>
       <emu-note>
-        <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and establishing its binding is handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
+        <p><emu-grammar>ClassDeclaration : DecoratorList? `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and establishing its binding is handled as part of the evaluation action for that production. See <emu-xref href="#sec-exports-runtime-semantics-evaluation"></emu-xref>.</p>
       </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-class-definitions-runtime-semantics-evaluation" type="sdo">
       <h1>Runtime Semantics: Evaluation</h1>
-      <emu-grammar>ClassDeclaration : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassDeclaration : DecoratorList? `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
-        1. Perform ? BindingClassDeclarationEvaluation of this |ClassDeclaration|.
+        1. If |DecoratorList?| is present, then
+          1. Let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else, let _decorators_ be a new empty List.
+        1. Perform ? BindingClassDeclarationEvaluation of this |ClassDeclaration| with argument _decorators_.
         1. Return ~empty~.
       </emu-alg>
       <emu-note>
-        <p><emu-grammar>ClassDeclaration : `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
+        <p><emu-grammar>ClassDeclaration : DecoratorList? `class` ClassTail</emu-grammar> only occurs as part of an |ExportDeclaration| and is never directly evaluated.</p>
       </emu-note>
-      <emu-grammar>ClassExpression : `class` ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : DecoratorList? `class` ClassTail</emu-grammar>
       <emu-alg>
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined* and *""*.
+        1. If |DecoratorList?| is present, then
+          1. Let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else, let _decorators_ be a new empty List.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments *undefined*, *""*, and _decorators_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
         1. Return _value_.
       </emu-alg>
-      <emu-grammar>ClassExpression : `class` BindingIdentifier ClassTail</emu-grammar>
+      <emu-grammar>ClassExpression : DecoratorList? `class` BindingIdentifier ClassTail</emu-grammar>
       <emu-alg>
         1. Let _className_ be StringValue of |BindingIdentifier|.
-        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_ and _className_.
+        1. If |DecoratorList?| is present, then
+          1. Let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+        1. Else, let _decorators_ be a new empty List.
+        1. Let _value_ be ? ClassDefinitionEvaluation of |ClassTail| with arguments _className_, _className_, and _decorators_.
         1. Set _value_.[[SourceText]] to the source text matched by |ClassExpression|.
         1. Return _value_.
       </emu-alg>
@@ -28069,10 +28650,10 @@
           `export` ExportFromClause FromClause `;`
           `export` NamedExports `;`
           `export` VariableStatement[~Yield, +Await]
-          `export` Declaration[~Yield, +Await]
+          DecoratorList[~Yield, +Await]? `export` Declaration[~Yield, +Await]
           `export` `default` HoistableDeclaration[~Yield, +Await, +Default]
-          `export` `default` ClassDeclaration[~Yield, +Await, +Default]
-          `export` `default` [lookahead &notin; { `function`, `async` [no LineTerminator here] `function`, `class` }] AssignmentExpression[+In, ~Yield, +Await] `;`
+          DecoratorList[~Yield, +Await]? `export` `default` ClassDeclaration[~Yield, +Await, +Default]
+          `export` `default` [lookahead &notin; { `function`, `async` [no LineTerminator here] `function`, `class`, `@` }] AssignmentExpression[+In, ~Yield, +Await] `;`
 
         ExportFromClause :
           `*`
@@ -28107,6 +28688,21 @@
         <emu-note>
           <p>The above rule means that each ReferencedBindings of |NamedExports| is treated as an |IdentifierReference|.</p>
         </emu-note>
+        <emu-grammar>ExportDeclaration : DecoratorList? `export` Declaration</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if |DecoratorList| is present and |Declaration| is not |ClassDeclaration|.
+          </li>
+          <li>
+            It is a Syntax Error if |DecoratorList| is present and |Declaration| is a |ClassDeclaration| and the |DecoratorList| of that |ClassDeclaration| is present.
+          </li>
+        </ul>
+        <emu-grammar>ExportDeclaration : DecoratorList? `export` `default` ClassDeclaration</emu-grammar>
+        <ul>
+          <li>
+            It is a Syntax Error if |DecoratorList| is present and the |DecoratorList| of |ClassDeclaration| is present.
+          </li>
+        </ul>
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-exportedbindings" oldids="sec-module-semantics-static-semantics-exportedbindings,sec-exports-static-semantics-exportedbindings" type="sdo">
@@ -28421,17 +29017,26 @@
         <emu-alg>
           1. Return ? Evaluation of |VariableStatement|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` Declaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : DecoratorList? `export` Declaration</emu-grammar>
         <emu-alg>
-          1. Return ? Evaluation of |Declaration|.
+          1. If |DecoratorList| is present, then
+            1. Assert: |Declaration| is a |ClassDeclaration| and the |DecoratorList| of that |ClassDeclaration| is not present.
+            1. Let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+            1. Perform ? BindingClassDeclarationEvaluation of |Declaration| with argument _decorators_.
+            1. Return ~empty~.
+          1. Else,
+            1. Return ? Evaluation of |Declaration|.
         </emu-alg>
         <emu-grammar>ExportDeclaration : `export` `default` HoistableDeclaration</emu-grammar>
         <emu-alg>
           1. Return ? Evaluation of |HoistableDeclaration|.
         </emu-alg>
-        <emu-grammar>ExportDeclaration : `export` `default` ClassDeclaration</emu-grammar>
+        <emu-grammar>ExportDeclaration : DecoratorList? `export` `default` ClassDeclaration</emu-grammar>
         <emu-alg>
-          1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration|.
+          1. If |DecoratorList| is present, then
+            1. Let _decorators_ be ? DecoratorListEvaluation of |DecoratorList|.
+          1. Else, let _decorators_ be a new empty List.
+          1. Let _value_ be ? BindingClassDeclarationEvaluation of |ClassDeclaration| with argument _decorators_.
           1. Let _className_ be the sole element of BoundNames of |ClassDeclaration|.
           1. If _className_ is *"\*default\*"*, then
             1. Let _env_ be the running execution context's LexicalEnvironment.
@@ -47180,6 +47785,11 @@ THH:mm:ss.sss
     <emu-prodref name="AsyncMethod"></emu-prodref>
     <emu-prodref name="AsyncFunctionBody"></emu-prodref>
     <emu-prodref name="AwaitExpression"></emu-prodref>
+    <emu-prodref name="DecoratorList"></emu-prodref>
+    <emu-prodref name="Decorator"></emu-prodref>
+    <emu-prodref name="DecoratorMemberExpression"></emu-prodref>
+    <emu-prodref name="DecoratorCallExpression"></emu-prodref>
+    <emu-prodref name="DecoratorParenthesizedExpression"></emu-prodref>
     <emu-prodref name="ClassDeclaration"></emu-prodref>
     <emu-prodref name="ClassExpression"></emu-prodref>
     <emu-prodref name="ClassTail"></emu-prodref>

--- a/spec.html
+++ b/spec.html
@@ -24262,6 +24262,7 @@
       <emu-alg>
         1. Let _addInitializerClosure_ be a new Abstract Closure with parameters (_initializer_) that captures _initializers_ and _decorationState_ and performs the following steps when called:
           1. If _decorationState_.[[Finished]] is *true*, throw a *TypeError* exception.
+          1. If IsCallable(_initializer_) is *false*, throw a *TypeError* exception.
           1. Append _initializer_ to _initializers_.
           1. Return *undefined*.
         1. Return CreateBuiltinFunction(_addInitializerClosure_, 1, *""*, « »).

--- a/spec.html
+++ b/spec.html
@@ -4646,6 +4646,47 @@
       </emu-table>
     </emu-clause>
 
+    <emu-clause id="sec-decoratordefinition-record-specification-type">
+      <h1>The DecoratorDefinition Record Specification Type</h1>
+      <p>
+        The DecoratorDefinition type is a Record used in the specification of
+        decorators.
+      </p>
+      <p>
+        Values of the DecoratorDefinition type are Record values whose fields
+        are defined by
+        <emu-xref href="#table-decoratordefinition-fields"></emu-xref>. Such
+        values are referred to as
+        <dfn variants="DecoratorDefinition Record"
+          >DecoratorDefinition Records</dfn
+        >.
+      </p>
+      <emu-table
+        id="table-decoratordefinition-fields"
+        caption="DecoratorDefinition Record Fields"
+      >
+        <table>
+          <tr>
+            <th>Field Name</th>
+            <th>Value</th>
+            <th>Meaning</th>
+          </tr>
+          <tr>
+            <td>[[Decorator]]</td>
+            <td>a function object.</td>
+            <td>The decorator function.</td>
+          </tr>
+          <tr>
+            <td>[[Receiver]]</td>
+            <td>a Reference Record or an ECMAScript language value</td>
+            <td>
+              The receiver that the decorator function should be called with.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-classelementdefinition-record-specification-type" oldids="sec-classfielddefinition-record-specification-type">
       <h1>The ClassElementDefinition Record Specification Type</h1>
       <p>The ClassElementDefinition type is a Record used in the specification of private and public, static and non-static class fields, methods, and accessors.</p>
@@ -4758,7 +4799,7 @@
               ~field~, ~method~, ~accessor~, ~getter~, ~setter~
             </td>
             <td>
-              a List of function objects or ~empty~
+              a List of DecoratorDefinition Records or ~empty~
             </td>
             <td>
               The decorators applied to the class element, if any.
@@ -24169,31 +24210,34 @@
     </emu-grammar>
 
     <emu-clause id="sec-decoratorevaluation" type="sdo">
-      <h1>Runtime Semantics: DecoratorEvaluation ( ): either a normal completion containing an ECMAScript language value or an abrupt completion</h1>
+      <h1>Runtime Semantics: DecoratorEvaluation ( ): either a normal completion containing a DecoratorDefinition Record or an abrupt completion</h1>
       <dl class="header">
       </dl>
       <emu-grammar>Decorator : `@` DecoratorMemberExpression</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |MemberExpression| that is covered by |DecoratorMemberExpression|.
         1. Let _ref_ be ? Evaluation of _expr_.
-        1. Return ? GetValue(_ref_).
+        1. Let _value_ be ? GetValue(_ref_).
+        1. Return DecoratorDefinition Record { [[Decorator]]: _value_, [[Receiver]]: _ref_ }.
       </emu-alg>
       <emu-grammar>Decorator : `@` DecoratorCallExpression</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |CallMemberExpression| that is covered by |DecoratorCallExpression|.
         1. Let _ref_ be ? Evaluation of _expr_.
-        1. Return ? GetValue(_ref_).
+        1. Let _value_ be ? GetValue(_ref_).
+        1. Return DecoratorDefinition Record { [[Decorator]]: _value_, [[Receiver]]: _ref_ }.
       </emu-alg>
       <emu-grammar>Decorator : `@` DecoratorParenthesizedExpression</emu-grammar>
       <emu-alg>
         1. Let _expr_ be the |MemberExpression| that is covered by |DecoratorParenthesizedExpression|.
         1. Let _ref_ be ? Evaluation of _expr_.
-        1. Return ? GetValue(_ref_).
+        1. Let _value_ be ? GetValue(_ref_).
+        1. Return DecoratorDefinition Record { [[Decorator]]: _value_, [[Receiver]]: _ref_ }.
       </emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-decoratorlistevaluation" type="sdo">
-      <h1>Runtime Semantics: DecoratorListEvaluation ( ): either a normal completion containing a List of ECMAScript language values or an abrupt completion</h1>
+      <h1>Runtime Semantics: DecoratorListEvaluation ( ): either a normal completion containing a List of DecoratorDefinition Records or an abrupt completion</h1>
       <dl class="header">
       </dl>
       <emu-grammar>DecoratorList : DecoratorList? Decorator</emu-grammar>
@@ -24328,7 +24372,9 @@
         1. If _decorators_ is ~empty~, return ~unused~.
         1. Let _key_ be _elementRecord_.[[Key]].
         1. Let _kind_ be _elementRecord_.[[Kind]].
-        1. For each element _decorator_ of _decorators_, do
+        1. For each element _decoratorRecord_ of _decorators_, do
+          1. Let _decorator_ be _decoratorRecord_.[[Decorator]].
+          1. Let _decoratorReceiver_ be _decoratorRecord_.[[Receiver]].
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
           1. Let _context_ be CreateDecoratorContextObject(_kind_, _key_, _extraInitializers_, _decorationState_, _isStatic_).
           1. Let _value_ be *undefined*.
@@ -24339,7 +24385,7 @@
             1. Set _value_ to OrdinaryObjectCreate(%Object.prototype%).
             1. Perform ! CreateDataPropertyOrThrow(_value_, *"get"*, _elementRecord_.[[Get]]).
             1. Perform ! CreateDataPropertyOrThrow(_value_, *"set"*, _elementRecord_.[[Set]]).
-          1. Let _newValue_ be ? Call(_decorator_, *undefined*, « _value_, _context_ »).
+          1. Let _newValue_ be ? Call(_decorator_, _decoratorReceiver_, « _value_, _context_ »).
           1. Set _decorationState_.[[Finished]] to *true*.
           1. If _kind_ is ~field~, then
             1. If IsCallable(_newValue_) is *true*, append _newValue_ to _elementRecord_.[[Initializers]].
@@ -24377,7 +24423,7 @@
       <h1>
         ApplyDecoratorsToClassDefinition (
           _classDef_: a function object,
-          _decorators_: a List of function objects,
+          _decorators_: a List of DecoratorDefinition Records,
           _className_: a property key or a Private Name,
           _extraInitializers_: a List of function objects,
         ): either a normal completion containing a function object, or an abrupt completion
@@ -24387,10 +24433,12 @@
         <dd>Applies the passed decorators to the passed class definition.</dd>
       </dl>
       <emu-alg>
-        1. For each element _decorator_ of _decorators_, do
+        1. For each element _decoratorRecord_ of _decorators_, do
+          1. Let _decorator_ be _decoratorRecord_.[[Decorator]].
+          1. Let _decoratorReceiver_ be _decoratorRecord_.[[Receiver]].
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
           1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _extraInitializers_, _decorationState_).
-          1. Let _newDef_ be ? Call(_decorator_, *undefined*, « _classDef_, _context_ »).
+          1. Let _newDef_ be ? Call(_decorator_, _decoratorReceiver_, « _classDef_, _context_ »).
           1. Set _decorationState_.[[Finished]] to *true*.
           1. If IsCallable(_newDef_) is *true*, then
             1. Set _classDef_ to _newDef_.
@@ -25103,7 +25151,7 @@
         Runtime Semantics: ClassDefinitionEvaluation (
           _classBinding_: a String or *undefined*,
           _className_: a property key or a Private Name,
-          _decorators_: a List of function objects,
+          _decorators_: a List of DecoratorDefinition Records,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">
@@ -25256,7 +25304,7 @@
     <emu-clause id="sec-runtime-semantics-bindingclassdeclarationevaluation" type="sdo">
       <h1>
         Runtime Semantics: BindingClassDeclarationEvaluation (
-          _decorators_: a List of function objects,
+          _decorators_: a List of DecoratorDefinition Records,
         ): either a normal completion containing a function object or an abrupt completion
       </h1>
       <dl class="header">

--- a/spec.html
+++ b/spec.html
@@ -1338,6 +1338,17 @@
                 An object valued property whose own and inherited property names are property names that are excluded from the `with` environment bindings of the associated object.
               </td>
             </tr>
+            <tr>
+              <td>
+                <dfn>@@metadata</dfn>
+              </td>
+              <td>
+                *"Symbol.metadata"*
+              </td>
+              <td>
+                An object valued property that contains metadata from decoration of a class.
+              </td>
+            </tr>
           </table>
         </emu-table>
       </emu-clause>
@@ -24319,6 +24330,7 @@
           _name_: a String, a Symbol, or a Private Name,
           _initializers_: a List of function objects,
           _decorationState_: a Record with a field [[Finished]] (a Boolean),
+          _metadataObj_: an Object,
           optional _isStatic_: a Boolean,
         ): an Object
       </h1>
@@ -24350,6 +24362,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"name"*, _name_).
         1. Let _addInitializer_ be CreateAddInitializerFunction(_initializers_, _decorationState_).
         1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"addInitializer"*, _addInitializer_).
+        1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"metadata"*, _metadataObj_).
         1. Return _contextObj_.
       </emu-alg>
     </emu-clause>
@@ -24360,6 +24373,7 @@
           _homeObject_: an Object,
           _elementRecord_: a ClassElementDefinition Record,
           _extraInitializers_: a List of function objects,
+          _metadataObj_: an Object,
           _isStatic_: a Boolean,
         ): either a normal completion containing ~unused~, or an abrupt completion
       </h1>
@@ -24376,7 +24390,7 @@
           1. Let _decorator_ be _decoratorRecord_.[[Decorator]].
           1. Let _decoratorReceiver_ be _decoratorRecord_.[[Receiver]].
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
-          1. Let _context_ be CreateDecoratorContextObject(_kind_, _key_, _extraInitializers_, _decorationState_, _isStatic_).
+          1. Let _context_ be CreateDecoratorContextObject(_kind_, _key_, _extraInitializers_, _decorationState_, _metadataObj_, _isStatic_).
           1. Let _value_ be *undefined*.
           1. If _kind_ is ~method~, set _value_ to _elementRecord_.[[Value]].
           1. Else if _kind_ is ~getter~, set _value_ to _elementRecord_.[[Get]].
@@ -24423,6 +24437,7 @@
           _decorators_: a List of DecoratorDefinition Records,
           _className_: a property key or a Private Name,
           _extraInitializers_: a List of function objects,
+          _metadataObj_: an Object or ~empty~,
         ): either a normal completion containing a function object, or an abrupt completion
       </h1>
       <dl class="header">
@@ -24434,7 +24449,7 @@
           1. Let _decorator_ be _decoratorRecord_.[[Decorator]].
           1. Let _decoratorReceiver_ be _decoratorRecord_.[[Receiver]].
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
-          1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _extraInitializers_, _decorationState_).
+          1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _extraInitializers_, _decorationState_, _metadataObj_).
           1. Let _newDef_ be ? Call(_decorator_, _decoratorReceiver_, « _classDef_, _context_ »).
           1. Set _decorationState_.[[Finished]] to *true*.
           1. If IsCallable(_newDef_) is *true*, then
@@ -24940,13 +24955,14 @@
           _homeObject_: an Object,
           _methodDefinition_: a ClassElementDefinition Record,
           _extraInitializers_: a List of function objects,
+          _metadataObj_: an Object or ~empty~,
           _isStatic_: a Boolean,
         ): either a normal completion containing ~unused~, or an abrupt completion
       </h1>
       <dl class="header">
       </dl>
       <emu-alg>
-        1. Perform ? ApplyDecoratorsToElementDefinition(_homeObject_, _methodDefinition_, _extraInitializers_, _isStatic_).
+        1. Perform ? ApplyDecoratorsToElementDefinition(_homeObject_, _methodDefinition_, _extraInitializers_, _metadataObj_, _isStatic_).
         1. Perform ? DefineMethodProperty(_homeObject_, _methodDefinition_, _isStatic_).
         1. Return ~unused~.
       </emu-alg>
@@ -25240,27 +25256,30 @@
         1. Set the running execution context's LexicalEnvironment to _env_.
         1. Let _instanceExtraInitializers_ be a new empty List.
         1. Let _staticExtraInitializers_ be a new empty List.
+        1. Let _metadataParent_ be ? Get(_constructorParent_, @@metadata).
+        1. If _metadataParent_ is *undefined*, let _metadataParent_ be %Object.prototype%.
+        1. Let _metadataObj_ be OrdinaryObjectCreate(_metadataParent_).
         1. For each element _e_ of _staticElements_, do
           1. If _e_ is a ClassElementDefinition Record and _e_.[[Kind]] is not ~field~, then
-            1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_F_, _e_, _staticExtraInitializers_, *true*)).
+            1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_F_, _e_, _staticExtraInitializers_, _metadataObj_, *true*)).
             1. If _result_ is an abrupt completion, then
               1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
               1. Return ? _result_.
         1. For each element _e_ of _instanceElements_, do
           1. If _e_.[[Kind]] is not ~field~, then
-            1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_proto_, _e_, _instanceExtraInitializers_, *true*)).
+            1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_proto_, _e_, _instanceExtraInitializers_, _metadataObj_, *true*)).
             1. If _result_ is an abrupt completion, then
               1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
               1. Return ? _result_.
         1. For each element _e_ of _staticElements_, do
           1. If _e_.[[Kind]] is ~field~, then
-            1. Let _result_ be Completion(ApplyDecoratorsToElementDefinition(_F_, _e_, _staticExtraInitializers_, *true*)).
+            1. Let _result_ be Completion(ApplyDecoratorsToElementDefinition(_F_, _e_, _staticExtraInitializers_, _metadataObj_, *true*)).
             1. If _result_ is an abrupt completion, then
               1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
               1. Return ? _result_.
         1. For each element _e_ of _instanceElements_, do
           1. If _e_.[[Kind]] is ~field~, then
-            1. Let _result_ be Completion(ApplyDecoratorsToElementDefinition(_proto_, _e_, _instanceExtraInitializers_, *false*)).
+            1. Let _result_ be Completion(ApplyDecoratorsToElementDefinition(_proto_, _e_, _instanceExtraInitializers_, _metadataObj_, *false*)).
             1. If _result_ is an abrupt completion, then
               1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
               1. Return ? _result_.
@@ -25268,11 +25287,12 @@
         1. Set _F_.[[Initializers]] to _instanceExtraInitializers_.
         1. Perform ? InitializePrivateMethods(_F_, _staticElements_).
         1. Let _classExtraInitializers_ be a new empty List.
-        1. Let _newF_ be Completion(ApplyDecoratorsToClassDefinition(_F_, _decorators_, _className_, _classExtraInitializers_)).
+        1. Let _newF_ be Completion(ApplyDecoratorsToClassDefinition(_F_, _decorators_, _className_, _classExtraInitializers_, _metadataObj_)).
         1. If _newF_ is an abrupt completion, then
           1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
           1. Return ? _result_.
         1. Set _F_ to _newF_.[[Value]].
+        1. Perform ! DefinePropertyOrThrow(_F_, @@metadata, PropertyDescriptor { [[Value]]: _metadataObj_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
         1. If _classBinding_ is not *undefined*, then
           1. Perform _classEnv_.InitializeBinding(_classBinding_, _F_).
         1. For each element _initializer_ of _staticExtraInitializers_, do
@@ -31040,6 +31060,12 @@
       <emu-clause id="sec-symbol.unscopables">
         <h1>Symbol.unscopables</h1>
         <p>The initial value of `Symbol.unscopables` is the well-known symbol @@unscopables (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
+        <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+      </emu-clause>
+
+      <emu-clause id="sec-symbol.metadata">
+        <h1>Symbol.metadata</h1>
+        <p>The initial value of `Symbol.metadata` is the well-known symbol @@metadata (<emu-xref href="#table-well-known-symbols"></emu-xref>).</p>
         <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
       </emu-clause>
     </emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -24330,7 +24330,7 @@
           _name_: a String, a Symbol, or a Private Name,
           _initializers_: a List of function objects,
           _decorationState_: a Record with a field [[Finished]] (a Boolean),
-          _metadataObj_: an Object,
+          _metadataObj_: an Object or ~empty~,
           optional _isStatic_: a Boolean,
         ): an Object
       </h1>
@@ -24362,7 +24362,7 @@
           1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"name"*, _name_).
         1. Let _addInitializer_ be CreateAddInitializerFunction(_initializers_, _decorationState_).
         1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"addInitializer"*, _addInitializer_).
-        1. Perform ! CreateDataPropertyOrThrow(_contextObj_, *"metadata"*, _metadataObj_).
+        1. If _metadata_ is not ~empty~, perform ! CreateDataPropertyOrThrow(_contextObj_, *"metadata"*, _metadataObj_).
         1. Return _contextObj_.
       </emu-alg>
     </emu-clause>
@@ -24373,7 +24373,7 @@
           _homeObject_: an Object,
           _elementRecord_: a ClassElementDefinition Record,
           _extraInitializers_: a List of function objects,
-          _metadataObj_: an Object,
+          _metadataObj_: an Object or ~empty~,
           _isStatic_: a Boolean,
         ): either a normal completion containing ~unused~, or an abrupt completion
       </h1>
@@ -25237,6 +25237,8 @@
         1. Perform CreateMethodProperty(_proto_, *"constructor"*, _F_).
         1. If |ClassBody?| is not present, let _elements_ be a new empty List.
         1. Else, let _elements_ be NonConstructorElements of |ClassBody|.
+        1. Let _hasDecorators_ be *false*.
+        1. If _decorators_ is not empty, set _hasDecorators_ to *true*.
         1. Let _instanceElements_ be a new empty List.
         1. Let _staticElements_ be a new empty List.
         1. For each |ClassElement| _e_ of _elements_, do
@@ -25248,6 +25250,7 @@
             1. Return ? _result_.
           1. Let _element_ be _result_.[[Value]].
           1. If _element_ is a ClassElementDefinition Record, then
+            1. If _e_.[[Decorators]] is not empty, set _hasDecorators_ to *true*.
             1. If IsStatic of _e_ is *false*, append _element_ to _instanceElements_.
             1. Else, append _element_ to _staticElements_.
           1. Else,
@@ -25256,9 +25259,11 @@
         1. Set the running execution context's LexicalEnvironment to _env_.
         1. Let _instanceExtraInitializers_ be a new empty List.
         1. Let _staticExtraInitializers_ be a new empty List.
-        1. Let _metadataParent_ be ? Get(_constructorParent_, @@metadata).
-        1. If _metadataParent_ is *undefined*, let _metadataParent_ be *null*.
-        1. Let _metadataObj_ be OrdinaryObjectCreate(_metadataParent_).
+        1. Let _metadataObj_ be ~empty~.
+        1. If _hasDecorators_ is *true*, then
+          1. If |ClassHeritage?| is present, let _metadataParent_ be ? Get(_constructorParent_, @@metadata).
+          1. Else, let _metadataParent_ be *null*.
+          1. Set _metadataObj_ to OrdinaryObjectCreate(_metadataParent_).
         1. For each element _e_ of _staticElements_, do
           1. If _e_ is a ClassElementDefinition Record and _e_.[[Kind]] is not ~field~, then
             1. Let _result_ be Completion(ApplyDecoratorsAndDefineMethod(_F_, _e_, _staticExtraInitializers_, _metadataObj_, *true*)).
@@ -25292,7 +25297,11 @@
           1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
           1. Return ? _result_.
         1. Set _F_ to _newF_.[[Value]].
-        1. Perform ! DefinePropertyOrThrow(_F_, @@metadata, PropertyDescriptor { [[Value]]: _metadataObj_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* }).
+        1. If _metadataObj_ is not ~empty~, then
+          1. Let _setMetadataResult_ be Completion(DefinePropertyOrThrow(_F_, @@metadata, PropertyDescriptor { [[Value]]: _metadataObj_, [[Writable]]: *true*, [[Enumerable]]: *false*, [[Configurable]]: *true* })).
+          1. If _setMetadataResult_ is an abrupt completion, then
+            1. Set the running execution context's PrivateEnvironment to _outerPrivateEnvironment_.
+            1. Return ? _setMetadataResult_.
         1. If _classBinding_ is not *undefined*, then
           1. Perform _classEnv_.InitializeBinding(_classBinding_, _F_).
         1. For each element _initializer_ of _staticExtraInitializers_, do
@@ -30619,6 +30628,7 @@
         <li>does not have a *"prototype"* property.</li>
         <li>has a *"length"* property whose value is *+0*<sub>𝔽</sub>.</li>
         <li>has a *"name"* property whose value is the empty String.</li>
+        <li>has a @@metadata property whose value is *null*, which is non-writable and non-configurable to prevent tampering that could be used to globally add metadata to all classes.</li>
       </ul>
       <emu-note>
         <p>The Function prototype object is specified to be a function object to ensure compatibility with ECMAScript code that was created prior to the ECMAScript 2015 specification.</p>


### PR DESCRIPTION
Adds the spec implementation for the current iteration of Decorator Metadata. Since this builds off the decorators proposal, this PR is currently being made against that proposals PR. Once that proposal is merged into the spec fully, this branch will be rebased and a new PR will be made.