### PR TITLE
Set decorationState.[[Finished]] to true when decorator throws

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -24794,8 +24794,9 @@
           1. Let _decoratorReceiver_ be _decoratorRecord_.[[Receiver]].
           1. Let _decorationState_ be the Record { [[Finished]]: *false* }.
           1. Let _context_ be CreateDecoratorContextObject(~class~, _className_, _extraInitializers_, _decorationState_).
-          1. Let _newDef_ be ? Call(_decorator_, _decoratorReceiver_, « _classDef_, _context_ »).
+          1. Let _newDef_ be Completion(Call(_decorator_, _decoratorReceiver_, « _classDef_, _context_ »)).
           1. Set _decorationState_.[[Finished]] to *true*.
+          1. ReturnIfAbrupt(_newDef_).
           1. If IsCallable(_newDef_) is *true*, then
             1. Set _classDef_ to _newDef_.
           1. Else if _newDef_ is not *undefined*, then

--- a/spec.html
+++ b/spec.html
@@ -24741,8 +24741,9 @@
             1. Set _value_ to OrdinaryObjectCreate(%Object.prototype%).
             1. Perform ! CreateDataPropertyOrThrow(_value_, *"get"*, _elementRecord_.[[Get]]).
             1. Perform ! CreateDataPropertyOrThrow(_value_, *"set"*, _elementRecord_.[[Set]]).
-          1. Let _newValue_ be ? Call(_decorator_, _decoratorReceiver_, « _value_, _context_ »).
+          1. Let _newValue_ be Completion(Call(_decorator_, _decoratorReceiver_, « _value_, _context_ »)).
           1. Set _decorationState_.[[Finished]] to *true*.
+          1. ReturnIfAbrupt(_newValue_).
           1. If _kind_ is ~field~, then
             1. If IsCallable(_newValue_) is *true*, prepend _newValue_ to _elementRecord_.[[Initializers]].
             1. Else if _newValue_ is not *undefined*, throw a *TypeError* exception.


### PR DESCRIPTION
Decorators have a "finished" state that is set when the decorator call is done, to prevent `addInitializer` to be called after the decorator is done.

The current proposed spec sets it to true only if the decorator call does not throw:
```js
class A {
  @((_, ctx) => {
    setTimeout(() => /* throws */ ctx.addInitializer(() => {}), 1000);
  })
  method() {}
}

try {
  class A {
    @((_, ctx) => {
      setTimeout(() => /* throws */ ctx.addInitializer(() => {}), 1000);
      return 3;
    })
    method() {}
  }
} finally {} // Decorating the class throws, because the decorator returns an invalid value

try {
  class A {
    @((_, ctx) => {
      setTimeout(() => /* does not throw */ ctx.addInitializer(() => {}), 1000);
      throw {}
    })
    method() {}
  }
} finally {} // Decorating the class throws, because the decorator throws
```

This PR updates the third case to also throw.

Fixes https://github.com/tc39/proposal-decorators/issues/500.
